### PR TITLE
Cache for Github Organization membership

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 import hudson.security.SecurityRealm;
@@ -75,7 +76,7 @@ public class GithubAuthenticationToken extends AbstractAuthenticationToken {
 	/**
 	 * Organization cache timeout in milliseconds
 	 */
-	private static final int GITHUB_ORGANIZATION_CACHE_TIMEOUT = TimeUnit.HOURS.toMillis(24);
+	private static final long GITHUB_ORGANIZATION_CACHE_TIMEOUT = TimeUnit.HOURS.toMillis(24);
 
     private final List<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
 


### PR DESCRIPTION
When Github Organization membership is used to check if users are allowed to perform actions, all non-admin users suffer from terrible UI performance, since every request to Jenkins does actual requests to Github to retrieve user memberships. 

This patch adds a simple 24 hour long cache for logged in user organizations, offering a significant performance improvement for non-admin users.

This patch was built and tested with actual organization account, it works.
