### PR TITLE
Don't overwrite user's email, if it already exists

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -318,7 +318,10 @@ public class GithubSecurityRealm extends SecurityRealm {
 			GHUser self = auth.getGitHub().getMyself();
 			User u = User.current();
 			u.setFullName(self.getName());
-			u.addProperty(new Mailer.UserProperty(self.getEmail()));
+			// Set email from github only if empty
+			if (u.getProperty(Mailer.UserProperty.class).getAddress() == null) {
+			    u.addProperty(new Mailer.UserProperty(self.getEmail()));
+			}
 		}
 		else {
 			Log.info("github did not return an access token.");


### PR DESCRIPTION
If the Jenkins user's email is already filled in, in _most_ cases it's the email the user wants, and overwriting it in each login is unexpected and undesired.
