### PR TITLE
Adding support for Embeddable Build Status Icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This defines:
 4. Check box to allow anonymous users READ permission for the /github-webhook.  
 This only has meaning if the github-plugin is installed and the remote github repository post commit hook has been setup accordingly.
 
-The plugin works but there are still some areas like form validation that need work.  And some other cases where exceptions are thrown when perhaps there is a better way.
+5. Check box to allow anonymous users READ permission for the ```/job/*/badge/icon``` [embeddable build status icon](https://wiki.jenkins-ci.org/display/JENKINS/Embeddable+Build+Status+Plugin).
 
 Notes:
 

--- a/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
@@ -69,12 +69,12 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
 	public GithubAuthorizationStrategy(String adminUserNames,
 			boolean authenticatedUserReadPermission, String organizationNames,
 			boolean allowGithubWebHookPermission, boolean allowCcTrayPermission,
-			boolean allowAnonymousReadPermission) {
+			boolean allowEmbeddableBuildStatusIconPermission, boolean allowAnonymousReadPermission) {
 		super();
 
 		rootACL = new GithubRequireOrganizationMembershipACL(adminUserNames,
 				organizationNames, authenticatedUserReadPermission,
-				allowGithubWebHookPermission, allowCcTrayPermission, allowAnonymousReadPermission);
+				allowGithubWebHookPermission, allowCcTrayPermission, allowEmbeddableBuildStatusIconPermission, allowAnonymousReadPermission);
 	}
 
 	private final GithubRequireOrganizationMembershipACL rootACL;
@@ -145,7 +145,14 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
 		return rootACL.isAllowCcTrayPermission();
 	}
 
-	
+	/**
+	 * @return
+	 * @see org.jenkinsci.plugins.GithubRequireOrganizationMembershipACL#isAllowEmbeddableBuildStatusIconPermission()
+	 */
+	public boolean isAllowEmbeddableBuildStatusIconPermission() {
+		return rootACL.isAllowEmbeddableBuildStatusIconPermission();
+	}
+
 	/**
 	 * @return
 	 * @see org.jenkinsci.plugins.GithubRequireOrganizationMembershipACL#isAllowAnonymousReadPermission()
@@ -153,7 +160,6 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
 	public boolean isAllowAnonymousReadPermission() {
 		return rootACL.isAllowAnonymousReadPermission();
 	}
-
 
 	@Extension
 	public static final class DescriptorImpl extends

--- a/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
@@ -29,6 +29,7 @@ package org.jenkinsci.plugins;
 import hudson.security.ACL;
 import hudson.security.Permission;
 
+import java.io.File;
 import java.net.URI;
 import java.util.LinkedList;
 import java.util.List;
@@ -52,7 +53,8 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 	private final boolean authenticatedUserReadPermission;
 	private final boolean allowGithubWebHookPermission;
     private final boolean allowCcTrayPermission;
-    private final boolean allowAnonymousReadPermission;
+	private final boolean allowEmbeddableBuildStatusIconPermission;
+	private final boolean allowAnonymousReadPermission;
 
 	/*
 	 * (non-Javadoc)
@@ -163,6 +165,17 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 					// else fall through to false.
 				}
 
+				if (allowEmbeddableBuildStatusIconPermission && currentUriIsEmbeddableBuildStatusIcon()) {
+					// allow if the permission was configured
+					if (checkReadPermission(permission)) {
+						log.info("Granting READ access for embeddable build status icon: "
+								+ requestURI());
+						return true;
+					}
+
+					// else false through to false
+				}
+
 				log.finer("Denying anonymous READ permission to url: "
 						+ requestURI());
 				return false;
@@ -188,6 +201,50 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
         return URI.create(requestURI()).getPath().equals(basePath + specificPath);
     }
 
+	private boolean currentUriIsEmbeddableBuildStatusIcon() {
+		/**
+		 * getJobNames() seems to result in an endless loop...
+		 *
+		 // iterate over job names and try to match against the request URI
+		 for (String jobName: Jenkins.getInstance().getJobNames()) {
+		    String testPath = basePath + "/job/" + jobName + "/badge/icon";
+
+		    if (requestPath.equals(testPath)) {
+		        hasMatch = true;
+		    }
+		 }
+		 */
+
+		// while iterating over the jobNames is more ideal, getJobNames() results
+		// in an endless loop, crashing Jenkins. As a workaround we are going to
+		// check the validity of the request by checking for:
+		// A. - the request was made to /.../job/.../badge/icon
+		//      example: /jenkins/job/ci-uploadr/badge/icon
+		//    - the path of this job exists on disk
+		//
+		// OR
+		//
+		// B. it is a request for a static resource (/.../static/...)
+		//    example: /jenkins/static/b43fedd5/plugin/embeddable-build-status/status/success.png
+		String requestPath  = URI.create(requestURI()).getPath();
+		String jobName      = requestPath
+				.replace("/badge/icon", "")
+				.replaceAll(".*/","");
+		String jobPath      = Jenkins.getInstance().getRootDir().getPath() + "/jobs/" + jobName;
+		String baseURI      = Jenkins.getInstance()
+				.getRootUrlFromRequest()
+				.replace("http://", "")
+				.replaceFirst("[^/]+/", "")
+				.replaceAll("/$", "");
+		Boolean isStaticRequest = (requestPath.startsWith("/" + baseURI + "/static/") &&
+				requestPath.contains("/plugin/embeddable-build-status/"));
+		Boolean isEmbeddableBadgeIcon = requestPath.equals("/" + baseURI + "/job/" + jobName + "/badge/icon");
+		Boolean jobPathExists   = new File(jobPath).exists();
+
+		// valid or not?
+		return ((isEmbeddableBadgeIcon && jobPathExists) || isStaticRequest);
+	}
+
     private String requestURI() {
         return Stapler.getCurrentRequest().getOriginalRequestURI();
     }
@@ -212,11 +269,13 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 			String organizationNames, boolean authenticatedUserReadPermission,
 			boolean allowGithubWebHookPermission,
             boolean allowCcTrayPermission,
+            boolean allowEmbeddableBuildStatusIconPermission,
 			boolean allowAnonymousReadPermission) {
 		super();
 		this.authenticatedUserReadPermission = authenticatedUserReadPermission;
 		this.allowGithubWebHookPermission = allowGithubWebHookPermission;
         this.allowCcTrayPermission = allowCcTrayPermission;
+		this.allowEmbeddableBuildStatusIconPermission = allowEmbeddableBuildStatusIconPermission;
         this.allowAnonymousReadPermission = allowAnonymousReadPermission;
 
 		this.adminUserNameList = new LinkedList<String>();
@@ -256,6 +315,10 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
     public boolean isAllowCcTrayPermission() {
         return allowCcTrayPermission;
     }
+
+	public boolean isAllowEmbeddableBuildStatusIconPermission() {
+		return allowEmbeddableBuildStatusIconPermission;
+	}
 
     /**
 	 * @return the allowAnonymousReadPermission

--- a/src/main/resources/org/jenkinsci/plugins/GithubAuthorizationStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/GithubAuthorizationStrategy/config.jelly
@@ -12,21 +12,24 @@
 			<f:textbox />
 		</f:entry>
 		
-		 <f:entry title="Grant READ permissions to all Authenticated Users" field="authenticatedUserReadPermission" help="/plugin/github-oauth/help/auth/grant-read-to-authenticated-help.html">
- 		<f:checkbox />
+		<f:entry title="Grant READ permissions to all Authenticated Users" field="authenticatedUserReadPermission" help="/plugin/github-oauth/help/auth/grant-read-to-authenticated-help.html">
+ 		    <f:checkbox />
  		</f:entry>
  		
- 		 <f:entry title="Grant READ permissions for /github-webhook" field="allowGithubWebHookPermission" help="/plugin/github-oauth/help/auth/grant-read-to-github-webhook-help.html">
- 		<f:checkbox />
+ 		<f:entry title="Grant READ permissions for /github-webhook" field="allowGithubWebHookPermission" help="/plugin/github-oauth/help/auth/grant-read-to-github-webhook-help.html">
+ 		    <f:checkbox />
  		</f:entry>
  		
- 		 <f:entry title="Grant READ permissions for /cc.xml" field="allowCcTrayPermission" help="/plugin/github-oauth/help/auth/grant-read-to-cctray-help.html">
- 		<f:checkbox />
+ 		<f:entry title="Grant READ permissions for /job/*/badge/icon" field="allowEmbeddableBuildStatusIconPermission" help="/plugin/github-oauth/help/auth/grant-read-to-embedable-build-status-icon-help.html">
+ 		    <f:checkbox />
  		</f:entry>
 
- 		 <f:entry title="Grant READ permissions for Anonymous Users" field="allowAnonymousReadPermission" help="/plugin/github-oauth/help/auth/grant-read-to-anonymous-help.html">
- 		<f:checkbox />
+ 		<f:entry title="Grant READ permissions for /cc.xml" field="allowCcTrayPermission" help="/plugin/github-oauth/help/auth/grant-read-to-cctray-help.html">
+ 		    <f:checkbox />
  		</f:entry>
-		
+
+ 		<f:entry title="Grant READ permissions for Anonymous Users" field="allowAnonymousReadPermission" help="/plugin/github-oauth/help/auth/grant-read-to-anonymous-help.html">
+ 		    <f:checkbox />
+ 		</f:entry>
 	</f:section>
 </j:jelly>

--- a/src/main/webapp/help/auth/grant-read-to-embedable-build-status-icon-help.html
+++ b/src/main/webapp/help/auth/grant-read-to-embedable-build-status-icon-help.html
@@ -1,0 +1,15 @@
+<div>
+    <p>
+        The <a href="https://wiki.jenkins-ci.org/display/JENKINS/Embeddable+Build+Status+Plugin">Embeddable Build Status
+        Plugin</a>
+        allows Jenkins to expose the current status of your build as an image in a fixed URL. You can put this URL into
+        other sites
+        (such as GitHub README) so that people can see the current state of the build.
+    </p>
+
+    <p>
+        By enabling this permission you grant anonymous external READ access to the <b>/job/*/badge/icon</b> URLs so
+        that the icon is accessible.<br/>
+        e.g. http://localhost:8080/jenkins/job/jobName/badge/icon
+    </p>
+</div>


### PR DESCRIPTION
## This pull request adds support for passthrough of the embeddable build status icon(s)

(see #5 for more information / history)
### To enable the embeddable build status icon passthrough

To enable the embeddable build status icon passthrough, perform the following steps:
### 1. manually upload the plugin and restart Jenkins

Package the plugin:

```
mvn package
```

and upload it:

![upload](https://dl.dropbox.com/s/srukykaaqump9a5/Jenkins%20-%20Upload%20Plugin.png?token_hash=AAHTVZzA5tVLWcZKBKx-iYcUY_K4VwEQSw4ie9n0lfEphg&dl=1)
### 2. configure Jenkins' global security

![configure](https://dl.dropbox.com/s/g0pqf1jrthw5wll/Jenkins%20-%20Configure%20Global%20Security.png?token_hash=AAG94N3LRZ5DBaI_pRLIhNKWgvRpKYVyKoRpLUlXSS0h7w&dl=1)
### 3. enable READ access to the build status icon

![enable read](https://dl.dropbox.com/s/sf731hr9f4glsm8/Jenkins%20-%20enable%20build%20status%20icon.png?token_hash=AAFO326GiOQkqvvHdL-xv23N0Wv_QlxGasZCZ0tyJe6Yrw&dl=1)
### 4. open one of the jobs' [embeddable build status](https://wiki.jenkins-ci.org/display/JENKINS/Embeddable+Build+Status+Plugin)

![job](https://wiki.jenkins-ci.org/download/attachments/60918124/snapshot1.png?version=2&modificationDate=1336589268000)
### 5. and use the embeddable build status icon [externally](https://github.com/PhenotypeFoundation/GSCF#war-files)

![icon](https://wiki.jenkins-ci.org/download/attachments/60918124/ebs.png?version=1&modificationDate=1336586636000)
