### PR TITLE
Added support for granting read access to non-github authenticated users.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
@@ -67,13 +67,14 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
 	 */
 	@DataBoundConstructor
 	public GithubAuthorizationStrategy(String adminUserNames,
-			boolean authenticatedUserReadPermission, String organizationNames,
+			boolean authenticatedUserReadPermission, boolean nonGitHubAuthenticatedUserReadPermission,
+			String organizationNames,
 			boolean allowGithubWebHookPermission, boolean allowCcTrayPermission,
 			boolean allowAnonymousReadPermission) {
 		super();
 
 		rootACL = new GithubRequireOrganizationMembershipACL(adminUserNames,
-				organizationNames, authenticatedUserReadPermission,
+				organizationNames, authenticatedUserReadPermission, nonGitHubAuthenticatedUserReadPermission,
 				allowGithubWebHookPermission, allowCcTrayPermission, allowAnonymousReadPermission);
 	}
 
@@ -127,6 +128,14 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
 	 */
 	public boolean isAuthenticatedUserReadPermission() {
 		return rootACL.isAuthenticatedUserReadPermission();
+	}
+	
+	/**
+	 * @return
+	 * @see org.jenkinsci.plugins.GithubRequireOrganizationMembershipACL#isNonGitHubAuthenticatedUserReadPermission()
+	 */
+	public boolean isNonGitHubAuthenticatedUserReadPermission() {
+		return rootACL.isNonGitHubAuthenticatedUserReadPermission();
 	}
 
 	/**

--- a/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
@@ -46,10 +46,11 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 
 	private static final Logger log = Logger
 			.getLogger(GithubRequireOrganizationMembershipACL.class.getName());
-
+	
 	private final List<String> organizationNameList;
 	private final List<String> adminUserNameList;
 	private final boolean authenticatedUserReadPermission;
+	private final boolean nonGitHubAuthenticatedUserReadPermission;
 	private final boolean allowGithubWebHookPermission;
     private final boolean allowCcTrayPermission;
     private final boolean allowAnonymousReadPermission;
@@ -118,7 +119,16 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 		} else {
 
 			String authenticatedUserName = a.getName();
-
+			
+			if (a.isAuthenticated() && authenticatedUserName.equals("authenticated")) {
+				if (nonGitHubAuthenticatedUserReadPermission && checkReadPermission(permission)) {
+					// if we support authenticated read and this is a read
+					// request we allow it
+					log.finest("Granting Authenticated User read permission to non-github user " + authenticatedUserName);
+					return true;
+				}
+			}
+			
 			if (authenticatedUserName.equals(SYSTEM.getPrincipal())) {
 				// give system user full access
 				log.finest("Granting Full rights to SYSTEM user.");
@@ -209,12 +219,15 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 	}
 
 	public GithubRequireOrganizationMembershipACL(String adminUserNames,
-			String organizationNames, boolean authenticatedUserReadPermission,
+			String organizationNames,
+			boolean authenticatedUserReadPermission,
+			boolean nonGitHubAuthenticatedUserReadPermission,
 			boolean allowGithubWebHookPermission,
             boolean allowCcTrayPermission,
 			boolean allowAnonymousReadPermission) {
 		super();
 		this.authenticatedUserReadPermission = authenticatedUserReadPermission;
+		this.nonGitHubAuthenticatedUserReadPermission = nonGitHubAuthenticatedUserReadPermission;
 		this.allowGithubWebHookPermission = allowGithubWebHookPermission;
         this.allowCcTrayPermission = allowCcTrayPermission;
         this.allowAnonymousReadPermission = allowAnonymousReadPermission;
@@ -247,6 +260,10 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 
 	public boolean isAuthenticatedUserReadPermission() {
 		return authenticatedUserReadPermission;
+	}
+	
+	public boolean isNonGitHubAuthenticatedUserReadPermission() {
+		return nonGitHubAuthenticatedUserReadPermission;
 	}
 
 	public boolean isAllowGithubWebHookPermission() {

--- a/src/main/resources/org/jenkinsci/plugins/GithubAuthorizationStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/GithubAuthorizationStrategy/config.jelly
@@ -12,10 +12,14 @@
 			<f:textbox />
 		</f:entry>
 		
-		 <f:entry title="Grant READ permissions to all Authenticated Users" field="authenticatedUserReadPermission" help="/plugin/github-oauth/help/auth/grant-read-to-authenticated-help.html">
+		 <f:entry title="Grant READ permissions to all Authenticated GitHub Users" field="authenticatedUserReadPermission" help="/plugin/github-oauth/help/auth/grant-read-to-authenticated-help.html">
  		<f:checkbox />
  		</f:entry>
  		
+		 <f:entry title="Grant READ permissions to all Authenticated Users" field="nonGitHubAuthenticatedUserReadPermission" help="/plugin/github-oauth/help/auth/grant-read-to-non-github-authenticated-help.html">
+ 		<f:checkbox />
+ 		</f:entry>
+		
  		 <f:entry title="Grant READ permissions for /github-webhook" field="allowGithubWebHookPermission" help="/plugin/github-oauth/help/auth/grant-read-to-github-webhook-help.html">
  		<f:checkbox />
  		</f:entry>

--- a/src/main/webapp/help/auth/grant-read-to-non-github-authenticated-help.html
+++ b/src/main/webapp/help/auth/grant-read-to-non-github-authenticated-help.html
@@ -1,0 +1,3 @@
+<div>
+If checked will grant the read permission to all authenticated non-github users.
+</div>


### PR DESCRIPTION
We have been trying to use the copy-artifacts plugin with this plugin, and if you look in the code for copy-artifacts, at some point they create a UsernamePasswordAuthenticationToken and pass it to the ACL to check for "Authenticated" read access. This github-oauth plugin does not expect that, and the request ends up being denied. We were not sure if the original "allow read access" flag was intended to provide this too, so I added it as a separate option.
