### PR TITLE
GitHub API URI does not show the saved value

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -183,7 +183,7 @@ public class GithubSecurityRealm extends SecurityRealm {
 	 *
 	 * @return the URI to the API root of GitHub or GitHub Enterprise.
 	 */
-	private String getGithubApiUri() {
+	public String getGithubApiUri() {
 		return githubApiUri;
 	}
 


### PR DESCRIPTION
Environment
- Jenkins 1.516, OpenJDK 7, Ubuntu Server 64bit 13.04
- github-oauth-plugin 0.14-SNAPSHOT 6b0449ccec7eec6ec5578fc0ffd1d89036062c09

Steps to reproduce
1. Open "Configure Global Security"
2. Select "Github Authentication Plugin" security realm
3. Set "GitHub API URI" "https://github.company.com/api/v3"
4. Save configuration
5. Reopen "Configure Global Security"
6. "GitHub API URI" is reset to "https://api.github.com"

Expected
- "GitHub API URI" should be "https://github.company.com/api/v3"
