### PR TITLE
Dont attempt to set email address property for a user upon login

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -369,6 +369,10 @@ public class GithubSecurityRealm extends SecurityRealm {
 			GHUser self = auth.getGitHub().getMyself();
 			User u = User.current();
 			u.setFullName(self.getName());
+			// Set email from github only if empty
+		    if (!u.getProperty(Mailer.UserProperty.class).hasExplicitlyConfiguredAddress()) {
+			    u.addProperty(new Mailer.UserProperty(self.getEmail()));
+		    }
 		}
 		else {
 			Log.info("Github did not return an access token.");


### PR DESCRIPTION
This causes performance issues when logging in. 

```
if (u.getProperty(Mailer.UserProperty.class).getAddress() == null)
```

This ultimately invokes 

```
AbstractProject.hasParticipant()
```

on each and every project. 
We have hundreds of projects and this causes logging in to take forever ( more than 5 minutes) .
