### PR TITLE
Jenkins CLI public key authentication was not working with the Github OAuth plugin.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -485,13 +485,13 @@ public class GithubSecurityRealm extends SecurityRealm {
 		try {
 
 			GroupDetails group = null;
-            try {
-                group = loadGroupByGroupname(username);
-            } catch (DataRetrievalFailureException e) {
-                LOGGER.config("No group found with name: " + username);
-            } catch (UsernameNotFoundException e) {
-                LOGGER.config("No group found with name: " + username);
-            }
+			try {
+				group = loadGroupByGroupname(username);
+			} catch (DataRetrievalFailureException e) {
+				LOGGER.config("No group found with name: " + username);
+			} catch (UsernameNotFoundException e) {
+				LOGGER.config("No group found with name: " + username);
+			}
 
 			if (group != null) {
 				throw new UsernameNotFoundException ("user("+username+") is also an organization");


### PR DESCRIPTION
Jenkins CLI should work with public key authentication as described here:
https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+CLI

It was not working because the method that's called when a CLI request is made was not implemented. It now simply calls the loadUserByUsername method of the outer class.
