### PR TITLE
added an "isUseRepositoryPermissions" so the admin checkbox in jelly works

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
@@ -135,6 +135,14 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
 
 	/**
 	 * @return
+	 * @see org.jenkinsci.plugins.GithubRequireOrganizationMembershipACL#isUseRepositoryPermissions()
+	 */
+	public boolean isUseRepositoryPermissions() {
+		return rootACL.isUseRepositoryPermissions();
+	}
+
+	/**
+	 * @return
 	 * @see org.jenkinsci.plugins.GithubRequireOrganizationMembershipACL#isAuthenticatedUserReadPermission()
 	 */
 	public boolean isAuthenticatedUserReadPermission() {


### PR DESCRIPTION
This is the final step that goes with #17 to allow admins to configure whether to use per-job repository permissions
