### PR TITLE
Allow users to create, configure and delete their own jobs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
@@ -68,14 +68,15 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
 	@DataBoundConstructor
 	public GithubAuthorizationStrategy(String adminUserNames,
 			boolean authenticatedUserReadPermission, boolean useRepositoryPermissions,
-                        String organizationNames,
+                        boolean authenticatedUserCreateJobPermission, String organizationNames,
 			boolean allowGithubWebHookPermission, boolean allowCcTrayPermission,
 			boolean allowAnonymousReadPermission) {
 		super();
 
 		rootACL = new GithubRequireOrganizationMembershipACL(adminUserNames,
 				organizationNames, authenticatedUserReadPermission,
-                                useRepositoryPermissions, allowGithubWebHookPermission,
+                                useRepositoryPermissions, authenticatedUserCreateJobPermission,
+                                allowGithubWebHookPermission,
                                 allowCcTrayPermission, allowAnonymousReadPermission);
 	}
 
@@ -139,6 +140,14 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
 	 */
 	public boolean isUseRepositoryPermissions() {
 		return rootACL.isUseRepositoryPermissions();
+	}
+
+	/**
+	 * @return
+	 * @see org.jenkinsci.plugins.GithubRequireOrganizationMembershipACL#isAuthenticatedUserCreateJobPermission()
+	 */
+	public boolean isAuthenticatedUserCreateJobPermission() {
+		return rootACL.isAuthenticatedUserCreateJobPermission();
 	}
 
 	/**

--- a/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
@@ -27,6 +27,7 @@ THE SOFTWARE.
 package org.jenkinsci.plugins;
 
 import hudson.model.AbstractProject;
+import hudson.model.Item;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.UserRemoteConfig;
 import hudson.scm.SCM;
@@ -56,6 +57,7 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 	private final List<String> adminUserNameList;
 	private final boolean authenticatedUserReadPermission;
         private final boolean useRepositoryPermissions;
+        private final boolean authenticatedUserCreateJobPermission;
 	private final boolean allowGithubWebHookPermission;
     private final boolean allowCcTrayPermission;
     private final boolean allowAnonymousReadPermission;
@@ -113,6 +115,10 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 							+ candidateName);
 				return true;
 				}
+			}
+
+			if (authenticatedUserCreateJobPermission && permission.equals(Item.CREATE)) {
+				return true;
 			}
 
 			for (String organizationName : this.organizationNameList) {
@@ -220,7 +226,18 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
         String repositoryName = getRepositoryName();
 
         if (repositoryName == null) {
-            return false;
+            if (authenticatedUserCreateJobPermission) {
+                if (permission.equals(Item.READ) ||
+                        permission.equals(Item.CONFIGURE) ||
+                        permission.equals(Item.DELETE) ||
+                        permission.equals(Item.EXTENDED_READ)) {
+                    return true;
+                } else {
+                    return false;
+                }
+            } else {
+                return false;
+            }
         } else if (checkReadPermission(permission) &&
                 authenticationToken.isPublicRepository(repositoryName)) {
             return true;
@@ -249,12 +266,14 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 	public GithubRequireOrganizationMembershipACL(String adminUserNames,
 			String organizationNames, boolean authenticatedUserReadPermission,
                         boolean useRepositoryPermissions,
+                        boolean authenticatedUserCreateJobPermission,
 			boolean allowGithubWebHookPermission,
             boolean allowCcTrayPermission,
 			boolean allowAnonymousReadPermission) {
 		super();
 		this.authenticatedUserReadPermission = authenticatedUserReadPermission;
                 this.useRepositoryPermissions = useRepositoryPermissions;
+                this.authenticatedUserCreateJobPermission = authenticatedUserCreateJobPermission;
 		this.allowGithubWebHookPermission = allowGithubWebHookPermission;
         this.allowCcTrayPermission = allowCcTrayPermission;
         this.allowAnonymousReadPermission = allowAnonymousReadPermission;
@@ -282,6 +301,7 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 			List<String> organizationNameList,
 			boolean authenticatedUserReadPermission,
                         boolean useRepositoryPermissions,
+                        boolean authenticatedUserCreateJobPermission,
 			boolean allowGithubWebHookPermission,
             boolean allowCcTrayPermission,
 			boolean allowAnonymousReadPermission,
@@ -291,6 +311,7 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 		this.organizationNameList = organizationNameList;
 		this.authenticatedUserReadPermission = authenticatedUserReadPermission;
                 this.useRepositoryPermissions = useRepositoryPermissions;
+                this.authenticatedUserCreateJobPermission = authenticatedUserCreateJobPermission;
 		this.allowGithubWebHookPermission = allowGithubWebHookPermission;
         this.allowCcTrayPermission = allowCcTrayPermission;
         this.allowAnonymousReadPermission = allowAnonymousReadPermission;
@@ -303,6 +324,7 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 			this.organizationNameList,
 			this.authenticatedUserReadPermission,
                         this.useRepositoryPermissions,
+			this.authenticatedUserCreateJobPermission,
 			this.allowGithubWebHookPermission,
             this.allowCcTrayPermission,
 			this.allowAnonymousReadPermission,
@@ -321,7 +343,11 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 		return useRepositoryPermissions;
 	}
 
-	public boolean isAuthenticatedUserReadPermission() {
+	public boolean isAuthenticatedUserCreateJobPermission() {
+		return authenticatedUserCreateJobPermission;
+	}
+
+        public boolean isAuthenticatedUserReadPermission() {
 		return authenticatedUserReadPermission;
 	}
 

--- a/src/main/resources/org/jenkinsci/plugins/GithubAuthorizationStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/GithubAuthorizationStrategy/config.jelly
@@ -20,6 +20,10 @@
  		<f:checkbox />
  		</f:entry>
  		
+		 <f:entry title="Grant CREATE Job permissions to all Authenticated Users" field="authenticatedUserCreateJobPermission" help="/plugin/github-oauth/help/auth/grant-create-job-to-authenticated-help.html">
+                <f:checkbox />
+                </f:entry>
+
  		 <f:entry title="Grant READ permissions for /github-webhook" field="allowGithubWebHookPermission" help="/plugin/github-oauth/help/auth/grant-read-to-github-webhook-help.html">
  		<f:checkbox />
  		</f:entry>

--- a/src/main/webapp/help/auth/grant-create-job-to-authenticated-help.html
+++ b/src/main/webapp/help/auth/grant-create-job-to-authenticated-help.html
@@ -1,0 +1,3 @@
+<div>
+If checked will grant the create job permission to all authenticated github users even those that aren't members of the declared organizations.
+</div>


### PR DESCRIPTION
Allow admins to setup a jenkins server in a way that lets them avoid becoming the bottleneck to a large development team. Each user is able to create their own jobs and once the job is created the regular authorization rules apply (this works well in combination when repository permissions are enabled). Users can create a new project, configure it with a github url they have rights to, then the repository permissions take over.

The admin page contains a new option "Allow Authenticated to CREATE new jobs". Several different permissions are required to create a new job & do an initial configuration 
- `Item.CREATE` to so the "new job" menu item appears
- `Item.READ`, `Item.EXTENDED_READ` and `Item.CONFIGURE` so the user can do an initial configuration of the new job
- `Item.DELETE` if users can create their own jobs it seems reasonable that they can delete them too.

When enabled authenticated users can CREATE new jobs & then configure jobs to setup the repository so
regular repository level authorization takes effect.
