### PR TITLE
Make no assumption about user's existence

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -431,8 +431,8 @@ public class GithubSecurityRealm extends SecurityRealm {
 			}
 		}, new UserDetailsService() {
 			public UserDetails loadUserByUsername(String username)
-					throws UsernameNotFoundException, DataAccessException {
-				throw new UsernameNotFoundException(username);
+					throws UserMayOrMayNotExistException, DataAccessException {
+				throw new UserMayOrMayNotExistException("Cannot verify users in this context");
 			}
 		});
 	}


### PR DESCRIPTION
Without looking up the user, we don't know if they exist, so don't tell Jenkins that it doesn't.
