### PR TITLE
Add support for allowing anonymous ViewStatus permission

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
@@ -65,8 +65,8 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
     			    boolean authenticatedUserReadPermission, boolean useRepositoryPermissions,
                     String organizationNames,
     			    boolean allowGithubWebHookPermission, boolean allowCcTrayPermission,
-    			    boolean allowAnonymousReadPermission) {
-    		this(adminUserNames, authenticatedUserReadPermission, useRepositoryPermissions, false, organizationNames, allowGithubWebHookPermission, allowCcTrayPermission, allowAnonymousReadPermission);
+    			    boolean allowAnonymousReadPermission, boolean allowAnonymousJobStatusPermission) {
+    		this(adminUserNames, authenticatedUserReadPermission, useRepositoryPermissions, false, organizationNames, allowGithubWebHookPermission, allowCcTrayPermission, allowAnonymousReadPermission, allowAnonymousJobStatusPermission);
     }
 
 	/**
@@ -78,14 +78,15 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
 			boolean authenticatedUserReadPermission, boolean useRepositoryPermissions,
                         boolean authenticatedUserCreateJobPermission, String organizationNames,
 			boolean allowGithubWebHookPermission, boolean allowCcTrayPermission,
-			boolean allowAnonymousReadPermission) {
+			boolean allowAnonymousReadPermission, boolean allowAnonymousJobStatusPermission) {
 		super();
 
 		rootACL = new GithubRequireOrganizationMembershipACL(adminUserNames,
 				organizationNames, authenticatedUserReadPermission,
                                 useRepositoryPermissions, authenticatedUserCreateJobPermission,
                                 allowGithubWebHookPermission,
-                                allowCcTrayPermission, allowAnonymousReadPermission);
+                                allowCcTrayPermission, allowAnonymousReadPermission,
+                                allowAnonymousJobStatusPermission);
 	}
 
 	private final GithubRequireOrganizationMembershipACL rootACL;
@@ -191,6 +192,13 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
 		return rootACL.isAllowAnonymousReadPermission();
 	}
 
+	/**
+	 * @see org.jenkinsci.plugins.GithubRequireOrganizationMembershipACL#isAllowAnonymousJobStatusPermission()
+	 * @return
+	 */
+	public boolean isAllowAnonymousJobStatusPermission() {
+		return rootACL.isAllowAnonymousJobStatusPermission();
+	}
 
 	@Extension
 	public static final class DescriptorImpl extends

--- a/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
@@ -61,6 +61,7 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 	private final boolean allowGithubWebHookPermission;
     private final boolean allowCcTrayPermission;
     private final boolean allowAnonymousReadPermission;
+    private final boolean allowAnonymousJobStatusPermission;
     private final AbstractProject project;
 
 	/*
@@ -157,6 +158,10 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 			}
 
 			if (authenticatedUserName.equals("anonymous")) {
+				if(checkJobStatusPermission(permission) && allowAnonymousJobStatusPermission) {
+					return true;
+				}
+
 				if (checkReadPermission(permission)) {
 					if (allowAnonymousReadPermission) {
 						return true;
@@ -223,6 +228,10 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 			return false;
 	}
 
+    private boolean checkJobStatusPermission(Permission permission) {
+        return permission.getId().equals("hudson.model.Item.ViewStatus");
+    }
+
     public boolean hasRepositoryPermission(GithubAuthenticationToken authenticationToken, Permission permission) {
         String repositoryName = getRepositoryName();
 
@@ -272,7 +281,8 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
                         boolean authenticatedUserCreateJobPermission,
 			boolean allowGithubWebHookPermission,
             boolean allowCcTrayPermission,
-			boolean allowAnonymousReadPermission) {
+			boolean allowAnonymousReadPermission,
+			boolean allowAnonymousJobStatusPermission) {
 		super();
 		this.authenticatedUserReadPermission = authenticatedUserReadPermission;
                 this.useRepositoryPermissions = useRepositoryPermissions;
@@ -280,6 +290,7 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 		this.allowGithubWebHookPermission = allowGithubWebHookPermission;
         this.allowCcTrayPermission = allowCcTrayPermission;
         this.allowAnonymousReadPermission = allowAnonymousReadPermission;
+        this.allowAnonymousJobStatusPermission = allowAnonymousJobStatusPermission;
 
 		this.adminUserNameList = new LinkedList<String>();
 
@@ -308,6 +319,7 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 			boolean allowGithubWebHookPermission,
             boolean allowCcTrayPermission,
 			boolean allowAnonymousReadPermission,
+			boolean allowAnonymousJobStatusPermission,
 			AbstractProject project) {
 		super();
 		this.adminUserNameList = adminUserNameList;
@@ -318,6 +330,7 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 		this.allowGithubWebHookPermission = allowGithubWebHookPermission;
         this.allowCcTrayPermission = allowCcTrayPermission;
         this.allowAnonymousReadPermission = allowAnonymousReadPermission;
+        this.allowAnonymousJobStatusPermission = allowAnonymousJobStatusPermission;
 		this.project = project;
 	}
 
@@ -331,6 +344,7 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 			this.allowGithubWebHookPermission,
             this.allowCcTrayPermission,
 			this.allowAnonymousReadPermission,
+			this.allowAnonymousJobStatusPermission,
 			project);
 	}
 
@@ -369,4 +383,7 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 		return allowAnonymousReadPermission;
 	}
 
+	public boolean isAllowAnonymousJobStatusPermission() {
+		return allowAnonymousJobStatusPermission;
+	}
 }

--- a/src/main/resources/org/jenkinsci/plugins/GithubAuthorizationStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/GithubAuthorizationStrategy/config.jelly
@@ -35,6 +35,10 @@
  		 <f:entry title="Grant READ permissions for Anonymous Users" field="allowAnonymousReadPermission" help="/plugin/github-oauth/help/auth/grant-read-to-anonymous-help.html">
  		<f:checkbox />
  		</f:entry>
+
+		  <f:entry title="Grant ViewStatus permissions for Anonymous Users" field="allowAnonymousJobStatusPermission" help="/plugin/github-oauth/help/auth/grant-viewstatus-to-anonymous-help.html">
+		 <f:checkbox />
+		 </f:entry>
 		
 	</f:section>
 </j:jelly>

--- a/src/main/webapp/help/auth/grant-viewstatus-to-anonymous-help.html
+++ b/src/main/webapp/help/auth/grant-viewstatus-to-anonymous-help.html
@@ -1,0 +1,4 @@
+<div>
+    If checked will grant the ViewStatus permission to everyone that connects to the Jenkins instance.  Anyone will be able to see the status of a job, but nothing else.
+    This is useful especially for plugins like <a href="https://wiki.jenkins-ci.org/display/JENKINS/Embeddable+Build+Status+Plugin">Embeddable Build Status Plugin</a>.
+</div>


### PR DESCRIPTION
This PR adds support for allowing anonymous ViewStatus permissions.

This is especially useful to work with plugins that require these permissions, for example for the [Embeddable Build Status Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Embeddable+Build+Status+Plugin) that requires this permission if you want badges to be reachable for anonymous users.

Fixes [JENKINS-24010](https://issues.jenkins-ci.org/browse/JENKINS-24010).