### PR TITLE
[DONT MERGE for now] [FIXED JENKINS-24866] Support authentication proxies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>github-api</artifactId>
-          <version>1.58</version>
+          <version>1.59</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
@@ -50,6 +50,7 @@ import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHTeam;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
 
 /**
  * @author mocleiri
@@ -84,7 +85,11 @@ public class GithubAuthenticationToken extends AbstractAuthenticationToken {
 		super(new GrantedAuthority[] {});
 
 		this.accessToken = accessToken;
-        this.gh = GitHub.connectUsingOAuth(githubServer, accessToken);
+        this.gh = new GitHubBuilder()
+                .withEndpoint(githubServer)
+                .withOAuthToken(accessToken)
+                .withConnector(new HttpConnectorWithJenkinsProxy())
+                .build();
 
         GHUser me = gh.getMyself();
         assert me!=null;

--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -619,7 +619,7 @@ public class GithubSecurityRealm extends SecurityRealm {
             ProxyConfiguration pc = Jenkins.getInstance().proxy;
             if (null != pc && null != pc.name && null != pc.getUserName()) {
                 setCredentials(
-                        AuthScope.ANY, // `new AuthScope(pc.name, pc.port)` does not work?
+                        new AuthScope(pc.name, pc.port), // You may need to set pc.name to proxy server's IP address
                         new UsernamePasswordCredentials(pc.getUserName(), pc.getPassword()));
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -52,7 +52,10 @@ import org.acegisecurity.userdetails.UserDetails;
 import org.acegisecurity.userdetails.UserDetailsService;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.apache.http.HttpEntity;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.conn.ProxySelectorRoutePlanner;
 import org.apache.http.impl.conn.SchemeRegistryFactory;
@@ -366,6 +369,7 @@ public class GithubSecurityRealm extends SecurityRealm {
 
         DefaultHttpClient httpclient = new DefaultHttpClient();
         httpclient.setRoutePlanner(new JenkinsProxyHttpRoutePlanner());
+        httpclient.setCredentialsProvider(new JenkinsProxyCredentialsProvider());
 
 		org.apache.http.HttpResponse response = httpclient.execute(httpost);
 
@@ -609,4 +613,15 @@ public class GithubSecurityRealm extends SecurityRealm {
         }
     }
 
+    private static class JenkinsProxyCredentialsProvider extends BasicCredentialsProvider {
+        public JenkinsProxyCredentialsProvider(){
+            super();
+            ProxyConfiguration pc = Jenkins.getInstance().proxy;
+            if (null != pc && null != pc.name && null != pc.getUserName()) {
+                setCredentials(
+                        AuthScope.ANY, // `new AuthScope(pc.name, pc.port)` does not work?
+                        new UsernamePasswordCredentials(pc.getUserName(), pc.getPassword()));
+            }
+        }
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -26,6 +26,7 @@ THE SOFTWARE.
  */
 package org.jenkinsci.plugins;
 
+import com.google.common.collect.Lists;
 import com.thoughtworks.xstream.converters.ConversionException;
 import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.MarshallingContext;
@@ -50,13 +51,11 @@ import org.acegisecurity.context.SecurityContextHolder;
 import org.acegisecurity.userdetails.UserDetails;
 import org.acegisecurity.userdetails.UserDetailsService;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
-import org.apache.commons.httpclient.URIException;
 import org.apache.http.HttpEntity;
-import org.apache.http.HttpHost;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.conn.ProxySelectorRoutePlanner;
+import org.apache.http.impl.conn.SchemeRegistryFactory;
 import org.apache.http.util.EntityUtils;
 import org.jfree.util.Log;
 import org.kohsuke.github.GHOrganization;
@@ -73,9 +72,12 @@ import org.springframework.dao.DataRetrievalFailureException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.net.InetSocketAddress;
 import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -363,10 +365,7 @@ public class GithubSecurityRealm extends SecurityRealm {
 				+ "client_secret=" + clientSecret + "&" + "code=" + code);
 
         DefaultHttpClient httpclient = new DefaultHttpClient();
-        HttpHost proxy = getProxy(httpost);
-        if (proxy != null) {
-            httpclient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
-        }
+        httpclient.setRoutePlanner(new JenkinsProxyHttpRoutePlanner());
 
 		org.apache.http.HttpResponse response = httpclient.execute(httpost);
 
@@ -423,27 +422,6 @@ public class GithubSecurityRealm extends SecurityRealm {
             throw (Error)new IllegalAccessError(e.getMessage()).initCause(e);
         } catch (InvocationTargetException e) {
             LOGGER.log(WARNING, "Failed to invoke fireAuthenticated", e);
-        }
-    }
-
-    /**
-     * Returns the proxy to be used when connecting to the given URI.
-     */
-    private HttpHost getProxy(HttpUriRequest method) throws URIException {
-
-        ProxyConfiguration proxy = Jenkins.getInstance().proxy;
-        if (proxy==null)    return null;    // defensive check
-
-        Proxy p = proxy.createProxy(method.getURI().getHost());
-        switch (p.type()) {
-        case DIRECT:
-            return null;        // no proxy
-        case HTTP:
-            InetSocketAddress sa = (InetSocketAddress) p.address();
-            return new HttpHost(sa.getHostName(),sa.getPort());
-        case SOCKS:
-        default:
-            return null;        // not supported yet
         }
     }
 
@@ -606,4 +584,29 @@ public class GithubSecurityRealm extends SecurityRealm {
 	private static final Logger LOGGER = Logger.getLogger(GithubSecurityRealm.class.getName());
 
     private static final String REFERER_ATTRIBUTE = GithubSecurityRealm.class.getName()+".referer";
+
+    private static class JenkinsProxySelector extends ProxySelector {
+        @Override
+        public List<Proxy> select(URI uri) {
+            ProxyConfiguration pc = Jenkins.getInstance().proxy;
+            if (null == pc) {
+                return Lists.newArrayList(Proxy.NO_PROXY); // defensive check
+            }
+
+            Proxy p = pc.createProxy(uri.getHost());
+            return Lists.newArrayList(p);
+        }
+
+        @Override
+        public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
+            // nop
+        }
+    }
+
+    private static class JenkinsProxyHttpRoutePlanner extends ProxySelectorRoutePlanner {
+        public JenkinsProxyHttpRoutePlanner() {
+            super(SchemeRegistryFactory.createDefault(), new JenkinsProxySelector());
+        }
+    }
+
 }

--- a/src/main/java/org/jenkinsci/plugins/HttpConnectorWithJenkinsProxy.java
+++ b/src/main/java/org/jenkinsci/plugins/HttpConnectorWithJenkinsProxy.java
@@ -1,0 +1,14 @@
+package org.jenkinsci.plugins;
+
+import hudson.ProxyConfiguration;
+import org.kohsuke.github.HttpConnector;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class HttpConnectorWithJenkinsProxy implements HttpConnector{
+    public HttpURLConnection connect(URL url) throws IOException {
+        return (HttpURLConnection)ProxyConfiguration.open(url);
+    }
+}


### PR DESCRIPTION
[JENKINS-24866](https://issues.jenkins-ci.org/browse/JENKINS-24866)

This pull request makes the plugin to work behind authentication proxies.
It will also resolve kohsuke/github-api#109.

* TODO
    * [x] [github-api](https://github.com/kohsuke/github-api) 1.59 is released
        * [x] kohsuke/github-api#124
    * [x] [github-api-plugin](https://github.com/jenkinsci/github-api-plugin/) 1.59 is released
    * [x] Remove `-SNAPSHOT` in pom.xml in this pull request