### PR TITLE
Fix for when user enters a badly formed github url for repo

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
@@ -257,7 +257,9 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
                 String repoUrl = userRemoteConfigs.get(0).getUrl();
                 if (repoUrl != null) {
                     GitHubRepositoryName githubRepositoryName = GitHubRepositoryName.create(repoUrl);
-                    repositoryName = githubRepositoryName.userName + "/" + githubRepositoryName.repositoryName;
+                    if (githubRepositoryName != null) {
+                        repositoryName = githubRepositoryName.userName + "/" + githubRepositoryName.repositoryName;
+                    }
                 }
             }
         }

--- a/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
@@ -333,5 +333,19 @@ public class GithubRequireOrganizationMembershipACLTest extends TestCase {
         assertFalse(acl.hasPermission(authenticationToken, Item.EXTENDED_READ));
     }
 
+    @Test
+    public void testCannotReadRepositoryWithInvalidRepoUrl() throws IOException {
+        GHMyself me = mockGHMyselfAs("Me");
+        mockReposFor(me, Arrays.asList("me/a-repo"));
+        mockOrgRepos(me, ImmutableMap.of("some-org", Arrays.asList("some-org/a-repo")));
+        String invalidRepoUrl = "git@github.com//some-org/a-repo.git";
+        Project mockProject = mockProject(invalidRepoUrl);
+        GithubRequireOrganizationMembershipACL acl = aclForProject(mockProject);
+
+        GithubAuthenticationToken authenticationToken = new GithubAuthenticationToken("accessToken", "https://api.github.com");
+
+        assertFalse(acl.hasPermission(authenticationToken, Item.READ));
+    }
+
 
 }


### PR DESCRIPTION
Previously it threw a NullPointerException which made the jenkins UI unusable
Now it treats that project as forbidden and will not show up (somewhat confusing as it "fails silently" but not sure what would be better)