### PR TITLE
Removed unnecessary permission

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -335,7 +335,7 @@ public class GithubSecurityRealm extends SecurityRealm {
         } else {
             // We need repo scope in order to access private repos
             // See https://developer.github.com/v3/oauth/#scopes
-            suffix = "&scope=read:org";
+            suffix = "&scope=repo:status,read:org";
         }
 
 		return new HttpRedirect(githubWebUri + "/login/oauth/authorize?client_id="

--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -335,7 +335,7 @@ public class GithubSecurityRealm extends SecurityRealm {
         } else {
             // We need repo scope in order to access private repos
             // See https://developer.github.com/v3/oauth/#scopes
-            suffix = "&scope=repo,read:org";
+            suffix = "&scope=read:org";
         }
 
 		return new HttpRedirect(githubWebUri + "/login/oauth/authorize?client_id="


### PR DESCRIPTION
Because the Github plugin only looks if you belong to an organisation and change the build status, the remaining permissions should be disabled by default. Specially the `repo` permission which grants read and write permission to all private and public repos.