### PR TITLE
JENKINS-28575 include GitHub teams as groups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>github-api</artifactId>
-          <version>1.58</version>
+          <version>1.67</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
                 <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>
-                    <artifactId>lifecycle-mapping</artifactId> 
+                    <artifactId>lifecycle-mapping</artifactId>
                     <version>1.0.0</version>
                     <configuration>
                         <lifecycleMappingMetadata>

--- a/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
@@ -27,7 +27,6 @@ THE SOFTWARE.
 package org.jenkinsci.plugins;
 
 import java.io.IOException;
-import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +45,7 @@ import hudson.security.SecurityRealm;
 
 import java.util.Collection;
 
+import org.jenkinsci.plugins.GithubOAuthUserDetails;
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.GrantedAuthorityImpl;
 import org.acegisecurity.providers.AbstractAuthenticationToken;
@@ -105,9 +105,17 @@ public class GithubAuthenticationToken extends AbstractAuthenticationToken {
 
         this.userName = this.me.getLogin();
         authorities.add(SecurityRealm.AUTHENTICATED_AUTHORITY);
-        for (String name : gh.getMyOrganizations().keySet())
-            authorities.add(new GrantedAuthorityImpl(name));
-	}
+        Map<String, Set<GHTeam>> myTeams = gh.getMyTeams();
+        for (String orgLogin : myTeams.keySet()) {
+            LOGGER.log(Level.FINE, "Fetch teams for user " + userName + " in organization " + orgLogin);
+            authorities.add(new GrantedAuthorityImpl(orgLogin));
+            for (GHTeam team : myTeams.get(orgLogin)) {
+                authorities.add(new GrantedAuthorityImpl(orgLogin + GithubOAuthGroupDetails.ORG_TEAM_SEPARATOR
+                        + team.getName()));
+            }
+        }
+
+    }
 
         /**
          * Necessary for testing
@@ -243,55 +251,90 @@ public class GithubAuthenticationToken extends AbstractAuthenticationToken {
         }
     }
 
-	private static final Logger LOGGER = Logger
-			.getLogger(GithubAuthenticationToken.class.getName());
+    private static final Logger LOGGER = Logger
+            .getLogger(GithubAuthenticationToken.class.getName());
 
-	public GHUser loadUser(String username) throws IOException {
-		if (gh != null && isAuthenticated())
-			return gh.getUser(username);
-		else
-			return null;
-	}
+    public GHUser loadUser(String username) {
+        try {
+            if (gh != null && isAuthenticated())
+                return gh.getUser(username);
+        } catch (IOException e) {
+            LOGGER.log(Level.FINEST, e.getMessage(), e);
+        }
+        return null;
+    }
 
-	public GHOrganization loadOrganization(String organization)
-			throws IOException {
-
-		if (gh != null && isAuthenticated())
-			return gh.getOrganization(organization);
-		else
-			return null;
-
-	}
+    public GHOrganization loadOrganization(String organization) {
+        try {
+            if (gh != null && isAuthenticated())
+                return gh.getOrganization(organization);
+        } catch (IOException e) {
+            LOGGER.log(Level.FINEST, e.getMessage(), e);
+        }
+        return null;
+    }
 
     public GHRepository loadRepository(String repositoryName) {
-            try {
-                if (gh != null && isAuthenticated()) {
-                    return gh.getRepository(repositoryName);
-                } else {
-                    return null;
-                }
-            } catch(FileNotFoundException e) {
-                LOGGER.log(Level.WARNING, "Looks like a bad GitHub URL OR the Jenkins user does not have access to the repository{0}", repositoryName);
-                return null;
-            } catch(IOException e) {
-                LOGGER.log(Level.WARNING, "Looks like a bad GitHub URL OR the Jenkins user does not have access to the repository{0}", repositoryName);
-                return null;
+        try {
+            if (gh != null && isAuthenticated()) {
+                return gh.getRepository(repositoryName);
             }
-	}
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING,
+                    "Looks like a bad GitHub URL OR the Jenkins user does not have access to the repository{0}",
+                    repositoryName);
+        }
+        return null;
+    }
 
-	public GHTeam loadTeam(String organization, String team) throws IOException {
-		if (gh != null && isAuthenticated()) {
+    public GHTeam loadTeam(String organization, String team) {
+        try {
+            GHOrganization org = loadOrganization(organization);
+            if (org != null) {
+                return org.getTeamByName(team);
+            }
+        } catch (IOException e) {
+            LOGGER.log(Level.FINEST, e.getMessage(), e);
+        }
+        return null;
+    }
 
-			GHOrganization org = gh.getOrganization(organization);
-
-			if (org != null) {
-				Map<String, GHTeam> teamMap = org.getTeams();
-
-				return teamMap.get(team);
-			} else
-				return null;
-
-		} else
-			return null;
-	}
+    /**
+     * @since 0.21
+     */
+    public GithubOAuthUserDetails getUserDetails(String username) {
+        GHUser user = loadUser(username);
+        if (user != null) {
+            List<GrantedAuthority> groups = new ArrayList<GrantedAuthority>();
+            try {
+                for (GHOrganization ghOrganization : user.getOrganizations()) {
+                    String orgLogin = ghOrganization.getLogin();
+                    LOGGER.log(Level.FINE, "Fetch teams for user " + username + " in organization " + orgLogin);
+                    groups.add(new GrantedAuthorityImpl(orgLogin));
+                    try {
+                        if (!me.isMemberOf(ghOrganization)) {
+                            continue;
+                        }
+                        Map<String, GHTeam> teams = ghOrganization.getTeams();
+                        for (String team : teams.keySet()) {
+                            if (teams.get(team).hasMember(user)) {
+                                groups.add(new GrantedAuthorityImpl(orgLogin + GithubOAuthGroupDetails.ORG_TEAM_SEPARATOR
+                                        + team));
+                            }
+                        }
+                    } catch (IOException ignore) {
+                        LOGGER.log(Level.FINEST, "not enough rights to list teams from " + orgLogin, ignore);
+                        continue;
+                    } catch (Error ignore) {
+                        LOGGER.log(Level.FINEST, "not enough rights to list teams from " + orgLogin, ignore);
+                        continue;
+                    }
+                }
+            } catch (IOException e) {
+                LOGGER.log(Level.FINE, e.getMessage(), e);
+            }
+            return new GithubOAuthUserDetails(user, groups.toArray(new GrantedAuthority[groups.size()]));
+        }
+        return null;
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/GithubOAuthGroupDetails.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubOAuthGroupDetails.java
@@ -4,6 +4,7 @@
 package org.jenkinsci.plugins;
 
 import org.kohsuke.github.GHOrganization;
+import org.kohsuke.github.GHTeam;
 
 import hudson.security.GroupDetails;
 
@@ -13,24 +14,42 @@ import hudson.security.GroupDetails;
  */
 public class GithubOAuthGroupDetails extends GroupDetails {
 
-	private final GHOrganization org;
+    private final GHOrganization org;
+    private final GHTeam team;
+    static final String ORG_TEAM_SEPARATOR = "*";
 
-	public GithubOAuthGroupDetails(GHOrganization org) {
-		super();
-		this.org = org;
-	}
+    /**
+    * Group based on organization name
+    * @param org
+    */
+    public GithubOAuthGroupDetails(GHOrganization org) {
+        super();
+        this.org = org;
+        this.team = null;
+    }
 
-	/* (non-Javadoc)
-	 * @see hudson.security.GroupDetails#getName()
-	 */
-	@Override
-	public String getName() {
-		if (org != null)
-			return org.getLogin();
-		else
-			return null;
-	}
+    /**
+    * Group based on team name
+     * @param ghTeam
+     */
+    public GithubOAuthGroupDetails(GHTeam team) {
+        super();
+        this.org = team.getOrganization();
+        this.team = team;
+    }
 
-	
+    /* (non-Javadoc)
+    * @see hudson.security.GroupDetails#getName()
+    */
+    @Override
+    public String getName() {
+        if (team != null)
+            return org.getLogin() + ORG_TEAM_SEPARATOR + team.getName();
+        if (org != null)
+            return org.getLogin();
+        return null;
+    }
+
+
 
 }

--- a/src/main/java/org/jenkinsci/plugins/GithubOAuthGroupDetails.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubOAuthGroupDetails.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package org.jenkinsci.plugins;
 

--- a/src/main/java/org/jenkinsci/plugins/GithubOAuthUserDetails.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubOAuthUserDetails.java
@@ -1,9 +1,10 @@
 /**
- * 
+ *
  */
 package org.jenkinsci.plugins;
 
 import org.acegisecurity.GrantedAuthority;
+import org.acegisecurity.userdetails.User;
 import org.acegisecurity.userdetails.UserDetails;
 import org.kohsuke.github.GHUser;
 
@@ -11,71 +12,12 @@ import org.kohsuke.github.GHUser;
  * @author Mike
  *
  */
-public class GithubOAuthUserDetails implements UserDetails {
+public class GithubOAuthUserDetails extends User implements UserDetails {
 
-	private final GHUser user;
+    private static final long serialVersionUID = 1L;
 
-	/**
-	 * 
-	 */
-	public GithubOAuthUserDetails(GHUser user) {
-		this.user = user;
-	}
-
-	/* (non-Javadoc)
-	 * @see org.acegisecurity.userdetails.UserDetails#getAuthorities()
-	 */
-	@Override
-	public GrantedAuthority[] getAuthorities() {
-		return new GrantedAuthority [] {};
-	}
-
-	/* (non-Javadoc)
-	 * @see org.acegisecurity.userdetails.UserDetails#getPassword()
-	 */
-	@Override
-	public String getPassword() {
-		return null;
-	}
-
-	/* (non-Javadoc)
-	 * @see org.acegisecurity.userdetails.UserDetails#getUsername()
-	 */
-	@Override
-	public String getUsername() {
-		return user.getLogin();
-	}
-
-	/* (non-Javadoc)
-	 * @see org.acegisecurity.userdetails.UserDetails#isAccountNonExpired()
-	 */
-	@Override
-	public boolean isAccountNonExpired() {
-		return true;
-	}
-
-	/* (non-Javadoc)
-	 * @see org.acegisecurity.userdetails.UserDetails#isAccountNonLocked()
-	 */
-	@Override
-	public boolean isAccountNonLocked() {
-		return true;
-	}
-
-	/* (non-Javadoc)
-	 * @see org.acegisecurity.userdetails.UserDetails#isCredentialsNonExpired()
-	 */
-	@Override
-	public boolean isCredentialsNonExpired() {
-		return true;
-	}
-
-	/* (non-Javadoc)
-	 * @see org.acegisecurity.userdetails.UserDetails#isEnabled()
-	 */
-	@Override
-	public boolean isEnabled() {
-		return true;
-	}
+    public GithubOAuthUserDetails(GHUser user, GrantedAuthority[] authorities) {
+        super(user.getLogin(), "", true, true, true, true, authorities);
+    }
 
 }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-28575

That pull request is missing updates on `GithubAuthorizationStrategy` and `GithubRequireOrganizationMembershipACL`.

It allows to reference GitHub teams as external groups in Jenkins in the form "`someOrganization*someTeam`"