### PR TITLE
Restrict default OAuthScope to "read:org"

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -188,7 +188,9 @@ public class GithubSecurityRealm extends SecurityRealm {
 	 * @return The default oauthScope string
 	 */
 	private String defaultOauthScope() {
-		return "repo,read:org";
+        // restrict default scope to just read:org, as it is the most
+        // restricted scope which will allow authentication
+		return "read:org";
 	}
 
 	/**

--- a/src/main/resources/org/jenkinsci/plugins/GithubSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/GithubSecurityRealm/config.jelly
@@ -17,7 +17,7 @@
 			<f:textbox />
 		</f:entry>
 		<f:entry title="OAuth Scope(s)" field="oauthScopes" help="/plugin/github-oauth/help/realm/oauth-scopes-help.html">
-			<f:textbox default="repo,read:org" />
+			<f:textbox default="read:org" />
 		</f:entry>
 	</f:section>
 </j:jelly>


### PR DESCRIPTION
The default scope for OAuth should arguably be as restricted as possible. The older default of "repo,read:org" requested push access to all of a user's repositories. For many users of the plugin, this was considered a deal-breaker before configurable OAuth Scopes, so there's no reason to assume that most users would want this moving forward.

For admins who prefer setting these values through the web UI, it's better to start with a more restricted scope, as it means that the admin doesn't need to share push privileges with Jenkins at any point during server configuration. This is also a better default for novice users who are not familiar with the GitHub OAuth docs and OAuth scoping.

This is, of course, a follow-up to discussions that we had with #35