### PR TITLE
Fix Java 7 compatibility when running unit tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.509</version><!-- which version of Jenkins is this plugin built
-            against? -->
+        <!-- which version of Jenkins is this plugin built against? -->
+        <version>1.586</version>
     </parent>
 
     <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Unit tests now work with Java 7.  Code review and testing would be much appreciated.

* relates to [JENKINS-21252][JENKINS-21252]
* fixes [JENKINS-29373]

[JENKINS-21252]: https://issues.jenkins-ci.org/browse/JENKINS-21252
[JENKINS-29373]: https://issues.jenkins-ci.org/browse/JENKINS-29373