### PR TITLE
Allow Jenkins email to be set using private email

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>github-api</artifactId>
-          <version>1.67</version>
+          <version>1.69</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
@@ -151,6 +151,13 @@ public class GithubAuthenticationToken extends AbstractAuthenticationToken {
     }
 
     /**
+     * Returns the GHMyself object from this instance.
+     */
+    public GHMyself getMyself() {
+        return me;
+    }
+
+    /**
      * For some reason I can't get the github api to tell me for the current
      * user the groups to which he belongs.
      *
@@ -332,5 +339,4 @@ public class GithubAuthenticationToken extends AbstractAuthenticationToken {
         }
         return null;
     }
-
 }

--- a/src/main/resources/org/jenkinsci/plugins/GithubSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/GithubSecurityRealm/config.jelly
@@ -5,11 +5,11 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:section title="Global Github OAuth Settings" >
         <f:entry title="GitHub Web URI"  field="githubWebUri" help="/plugin/github-oauth/help/realm/github-web-uri-help.html">
-            <f:textbox default="https://github.com" />
+            <f:textbox default="${descriptor.getDefaultGithubWebUri()}" />
         </f:entry>
 
         <f:entry title="GitHub API URI"  field="githubApiUri" help="/plugin/github-oauth/help/realm/github-api-uri-help.html">
-            <f:textbox default="https://api.github.com" />
+            <f:textbox default="${descriptor.getDefaultGithubApiUri()}" />
         </f:entry>
 
         <f:entry title="Client ID"  field="clientID" help="/plugin/github-oauth/help/realm/client-id-help.html">
@@ -21,7 +21,7 @@
         </f:entry>
 
         <f:entry title="OAuth Scope(s)" field="oauthScopes" help="/plugin/github-oauth/help/realm/oauth-scopes-help.html">
-            <f:textbox default="read:org" />
+            <f:textbox default="${descriptor.getDefaultOauthScopes()}" />
         </f:entry>
     </f:section>
 </j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/GithubSecurityRealmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubSecurityRealmTest.java
@@ -26,21 +26,56 @@ package org.jenkinsci.plugins;
 
 import java.io.IOException;
 import junit.framework.TestCase;
+import org.jenkinsci.plugins.GithubSecurityRealm.DescriptorImpl;
 import org.junit.runner.RunWith;
 import org.junit.Test;
 
 public class GithubSecurityRealmTest extends TestCase {
+
     @Test
     public void testEquals_true() {
         GithubSecurityRealm a = new GithubSecurityRealm(new String("http://jenkins.acme.com"), new String("http://jenkins.acme.com/api/v3"), new String("someid"), new String("somesecret"), new String("read:org"));
         GithubSecurityRealm b = new GithubSecurityRealm(new String("http://jenkins.acme.com"), new String("http://jenkins.acme.com/api/v3"), new String("someid"), new String("somesecret"), new String("read:org"));
         assertTrue(a.equals(b));
     }
+
     @Test
     public void testEquals_false() {
         GithubSecurityRealm a = new GithubSecurityRealm(new String("http://jenkins.acme.com"), new String("http://jenkins.acme.com/api/v3"), new String("someid"), new String("somesecret"), new String("read:org"));
         GithubSecurityRealm b = new GithubSecurityRealm(new String("http://jenkins.acme.com"), new String("http://jenkins.acme.com/api/v3"), new String("someid"), new String("somesecret"), new String("read:org,repo"));
         assertFalse(a.equals(b));
         assertFalse(a.equals(""));
+    }
+
+    @Test
+    public void testHasScope_true() {
+        GithubSecurityRealm a = new GithubSecurityRealm(new String("http://jenkins.acme.com"), new String("http://jenkins.acme.com/api/v3"), new String("someid"), new String("somesecret"), new String("read:org,user,user:email"));
+        assertTrue(a.hasScope(new String("user")));
+        assertTrue(a.hasScope(new String("read:org")));
+        assertTrue(a.hasScope(new String("user:email")));
+    }
+
+    @Test
+    public void testHasScope_false() {
+        GithubSecurityRealm a = new GithubSecurityRealm(new String("http://jenkins.acme.com"), new String("http://jenkins.acme.com/api/v3"), new String("someid"), new String("somesecret"), new String("read:org,user,user:email"));
+        assertFalse(a.hasScope(new String("somescope")));
+    }
+
+    @Test
+    public void testDescriptorImplGetDefaultGithubWebUri() {
+        DescriptorImpl descriptor = new DescriptorImpl();
+        assertTrue("https://github.com".equals(descriptor.getDefaultGithubWebUri()));
+    }
+
+    @Test
+    public void testDescriptorImplGetDefaultGithubApiUri() {
+        DescriptorImpl descriptor = new DescriptorImpl();
+        assertTrue("https://api.github.com".equals(descriptor.getDefaultGithubApiUri()));
+    }
+
+    @Test
+    public void testDescriptorImplGetDefaultOauthScopes() {
+        DescriptorImpl descriptor = new DescriptorImpl();
+        assertTrue("read:org,user:email".equals(descriptor.getDefaultOauthScopes()));
     }
 }


### PR DESCRIPTION
Update default OAuth scope to `read:org,user:email`.  This allows the Jenkins profile email to be set to the private primary GitHub email.

`user:email` scope is optional.  If an admin wishes to further restrict it they can.  It will fall back to attempting to read a public email.

fixes [JENKINS-27764][JENKINS-27764]

[JENKINS-27764]: https://issues.jenkins-ci.org/browse/JENKINS-27764