### PR TITLE
Reduce read access log messages to finest

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
@@ -161,11 +161,11 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
                     if (allowGithubWebHookPermission &&
                             (currentUriPathEquals("github-webhook") ||
                              currentUriPathEquals("github-webhook/"))) {
-                        log.info("Granting READ access for github-webhook url: " + requestURI());
+                        log.finest("Granting READ access for github-webhook url: " + requestURI());
                         return true;
                     }
                     if (allowCcTrayPermission && currentUriPathEquals("cc.xml")) {
-                        log.info("Granting READ access for cctray url: " + requestURI());
+                        log.finest("Granting READ access for cctray url: " + requestURI());
                         return true;
                     }
                     log.finer("Denying anonymous READ permission to url: " + requestURI());


### PR DESCRIPTION
When allowGithubWebHookPermission and/or allowCcTrayPermission is enabled, every request to those endpoints will produce a generic log message.  This can probably be reduced to the same log level as every other log message that occurs when access is granted on a request.