### PR TITLE
Fix JENKINS-34834

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
             <roles>
                 <role>maintainer</role>
             </roles>
-            <timezone>America/New_York</timezone>
+            <timezone>America/Los_Angeles</timezone>
         </developer>
     </developers>
 


### PR DESCRIPTION
GitHub no longer creates a default 'Owners' group (as of 2.4 or so)
Reference: https://help.github.com/articles/about-improved-organization-permissions/

Thus, a User can belong to an Organization without being in a Team on that Org. So we need to lookup both the User's organizations and teams and merge them when calculating the user's group memberships in Jenkins.

@reviewbybees 