### PR TITLE
[JENKINS-34775] Don't cast inconvertible un/pw token

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -628,6 +628,7 @@ public class GithubSecurityRealm extends SecurityRealm implements UserDetailsSer
      *
      * @param username
      * @return
+     * @throws UserMayOrMayNotExistException
      * @throws UsernameNotFoundException
      * @throws DataAccessException
      */
@@ -636,10 +637,18 @@ public class GithubSecurityRealm extends SecurityRealm implements UserDetailsSer
             throws UsernameNotFoundException, DataAccessException {
         GHUser user = null;
 
-        GithubAuthenticationToken authToken =  (GithubAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
+        Authentication token = SecurityContextHolder.getContext().getAuthentication();
 
-        if (authToken == null) {
+        if (token == null) {
             throw new UserMayOrMayNotExistException("Could not get auth token.");
+        }
+
+        GithubAuthenticationToken authToken;
+
+        if (token instanceof GithubAuthenticationToken) {
+            authToken = (GithubAuthenticationToken) token;
+        } else {
+            throw new UserMayOrMayNotExistException("Unexpected authentication type: " + token);
         }
 
         try {


### PR DESCRIPTION
Fixes [JENKINS-34775](https://issues.jenkins-ci.org/browse/JENKINS-34775).

The loadUserByUsername method expects to be able to get the current user's token with `SecurityContextHolder.getContext().getAuthentication()`, and assumes this method will return a `GithubAuthenticationToken`. When it returns a `UserPasswordAuthenticationToken` instead, a fatal cast was performed.

We now handle the case where the current authentication context contains a `UserPasswordAuthenticationToken` (by throwing an exception - so, not _successfully_ handled, but this prevents the `loadUserByUsername` failure bubbling up to become a job failure).