### PR TITLE
[JENKINS-16350] fix the logout -> immediate login

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubLogoutAction.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubLogoutAction.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 CloudBees, Inc., James Nord
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import hudson.Extension;
+import hudson.model.UnprotectedRootAction;
+import hudson.security.SecurityRealm;
+import jenkins.model.Jenkins;
+
+/**
+ * A page that shows a simple message when the user logs out.
+ * This prevents a logout -> login loop when using this security realm and Anonymous does not have {@code Overall.READ} permission.
+ */
+@Extension
+public class GithubLogoutAction implements UnprotectedRootAction {
+
+    /** The URL of the action. */
+    static final String POST_LOGOUT_URL = "githubLogout";
+
+    @Override
+    public String getDisplayName() {
+        return "Github Logout";
+    }
+
+    @Override
+    public String getIconFileName() {
+        // hide it
+        return null;
+    }
+
+    @Override
+    public String getUrlName() {
+        return POST_LOGOUT_URL;
+    }
+
+    @Restricted(NoExternalUse.class) // jelly only
+    public String getGitHubURL() {
+        SecurityRealm r = Jenkins.getInstance().getSecurityRealm();
+        if (r instanceof GithubSecurityRealm) {
+            GithubSecurityRealm ghsr = (GithubSecurityRealm) r;
+            return ghsr.getGithubWebUri();
+        }
+        // only called from the Jelly if the GithubSecurityRealm is set...
+        return "";
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
-Copyright (c) 2011 Michael O'Cleirigh
+Copyright (c) 2011-2016 Michael O'Cleirigh, James Nord, CloudBees, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -38,6 +38,7 @@ import hudson.model.listeners.ItemListener;
 import hudson.model.User;
 import hudson.ProxyConfiguration;
 import hudson.security.GroupDetails;
+import hudson.security.Permission;
 import hudson.security.SecurityRealm;
 import hudson.security.UserMayOrMayNotExistException;
 import hudson.tasks.Mailer;
@@ -577,6 +578,16 @@ public class GithubSecurityRealm extends SecurityRealm implements UserDetailsSer
     @Override
     public String getLoginUrl() {
         return "securityRealm/commenceLogin";
+    }
+
+    @Override
+    protected String getPostLogOutUrl(StaplerRequest req, Authentication auth) {
+        // if we just redirect to the root and anonymous does not have Overall read then we will start a login all over again.
+        // we are actually anonymous here as the security context has been cleared 
+        if (Jenkins.getInstance().hasPermission(Jenkins.READ)) {
+            return super.getPostLogOutUrl(req, auth);
+        }
+        return req.getContextPath()+ "/" + GithubLogoutAction.POST_LOGOUT_URL;
     }
 
     @Extension

--- a/src/main/resources/org/jenkinsci/plugins/GithubLogoutAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/GithubLogoutAction/index.jelly
@@ -1,0 +1,44 @@
+<!--
+ The MIT License
+ 
+ Copyright (c) 2016 CloudBees, Inc., James Nord
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+  <l:layout norefresh="true">
+    <l:main-panel>
+      <j:choose>
+        <j:when test="${h.isAnonymous()}">
+          <p>You are now logged out of Jenkins, however this has not logged you out of <a href="${it.gitHubURL}">GitHub</a>.</p>
+          <p>Have a nice day</p>
+        </j:when>
+        <j:otherwise>
+          <div style="font-size: +4">
+            <h2>Woo There....</h2>
+            <p>You are not logged out - don't run away!</p>
+            <p>Whilst you should been logged out you are not actually logged out...</p>
+          </div>
+        </j:otherwise>
+      </j:choose>
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/GithubLogoutAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/GithubLogoutAction/index.jelly
@@ -32,11 +32,9 @@
           <p>Have a nice day</p>
         </j:when>
         <j:otherwise>
-          <div style="font-size: +4">
-            <h2>Woo There....</h2>
-            <p>You are not logged out - don't run away!</p>
-            <p>Whilst you should been logged out you are not actually logged out...</p>
-          </div>
+          <h2>Woo There....</h2>
+          <p>You are not logged out - don't run away!</p>
+          <p>Whilst you should been logged out you are not actually logged out...</p>
         </j:otherwise>
       </j:choose>
     </l:main-panel>


### PR DESCRIPTION
When using a secured Jenkins without anonymous read on the main page the redirect at the end of the login would case Jenkins to redirect to the security realms login page, which would then cause you to be logged in.

This does not log you out of github but at least it means your JENKINS
cookie can not be snarfed by anyone for evil purposes.

[JENKINS-16350](https://issues.jenkins-ci.org/browse/JENKINS-16350)

//cc @reviewbybees (part work time)