### PR TITLE
Added support for SSL server name indication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.1</version>
+            <version>4.5</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -69,7 +69,8 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.jfree.util.Log;
 import org.kohsuke.github.GHEmail;
@@ -423,7 +424,7 @@ public class GithubSecurityRealm extends SecurityRealm implements UserDetailsSer
                 + "/login/oauth/access_token?" + "client_id=" + clientID + "&"
                 + "client_secret=" + clientSecret + "&" + "code=" + code);
 
-        DefaultHttpClient httpclient = new DefaultHttpClient();
+        CloseableHttpClient httpclient = HttpClients.createDefault();
         HttpHost proxy = getProxy(httpost);
         if (proxy != null) {
             httpclient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);


### PR DESCRIPTION
This plugin was not working for me when our GitHub Enterprise server was behind a shared reverse proxy that uses SNI to determine where to send traffic. Updated the `httpclient` dependency to take advantage of its built-in support for SNI.