### PR TITLE
Github rate limiting should always fail fast

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
@@ -40,6 +40,8 @@ import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHTeam;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
+import org.kohsuke.github.RateLimitHandler;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -165,7 +167,11 @@ public class GithubAuthenticationToken extends AbstractAuthenticationToken {
 
     public GitHub getGitHub() throws IOException {
         if (this.gh == null) {
-            this.gh = GitHub.connectUsingOAuth(this.githubServer, this.accessToken);
+            this.gh = GitHubBuilder.fromEnvironment()
+                    .withEndpoint(this.githubServer)
+                    .withOAuthToken(this.accessToken)
+                    .withRateLimitHandler(RateLimitHandler.FAIL)
+                    .build();
         }
         return gh;
     }

--- a/src/test/java/org/jenkinsci/plugins/GithubAuthenticationTokenTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubAuthenticationTokenTest.java
@@ -8,6 +8,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kohsuke.github.GHMyself;
 import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
+import org.kohsuke.github.RateLimitHandler;
 import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -18,7 +20,7 @@ import java.io.IOException;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({GitHub.class, Jenkins.class, GithubSecurityRealm.class})
+@PrepareForTest({GitHub.class, GitHubBuilder.class, Jenkins.class, GithubSecurityRealm.class})
 public class GithubAuthenticationTokenTest {
 
     @Mock
@@ -54,8 +56,14 @@ public class GithubAuthenticationTokenTest {
 
     private GHMyself mockGHMyselfAs(String username) throws IOException {
         GitHub gh = PowerMockito.mock(GitHub.class);
+        GitHubBuilder builder = PowerMockito.mock(GitHubBuilder.class);
         PowerMockito.mockStatic(GitHub.class);
-        PowerMockito.when(GitHub.connectUsingOAuth("https://api.github.com", "accessToken")).thenReturn(gh);
+        PowerMockito.mockStatic(GitHubBuilder.class);
+        PowerMockito.when(GitHubBuilder.fromEnvironment()).thenReturn(builder);
+        PowerMockito.when(builder.withEndpoint("https://api.github.com")).thenReturn(builder);
+        PowerMockito.when(builder.withOAuthToken("accessToken")).thenReturn(builder);
+        PowerMockito.when(builder.withRateLimitHandler(RateLimitHandler.FAIL)).thenReturn(builder);
+        PowerMockito.when(builder.build()).thenReturn(gh);
         GHMyself me = PowerMockito.mock(GHMyself.class);
         PowerMockito.when(gh.getMyself()).thenReturn(me);
         PowerMockito.when(me.getLogin()).thenReturn(username);

--- a/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
@@ -52,7 +52,9 @@ import org.kohsuke.github.GHPersonSet;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
 import org.kohsuke.github.PagedIterable;
+import org.kohsuke.github.RateLimitHandler;
 import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -72,7 +74,7 @@ import java.util.Set;
  * @author alex
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({GitHub.class, Jenkins.class, GithubSecurityRealm.class})
+@PrepareForTest({GitHub.class, GitHubBuilder.class, Jenkins.class, GithubSecurityRealm.class})
 public class GithubRequireOrganizationMembershipACLTest extends TestCase {
 
     @Mock
@@ -121,8 +123,14 @@ public class GithubRequireOrganizationMembershipACLTest extends TestCase {
 
     private GHMyself mockGHMyselfAs(String username) throws IOException {
         GitHub gh = PowerMockito.mock(GitHub.class);
+        GitHubBuilder builder = PowerMockito.mock(GitHubBuilder.class);
         PowerMockito.mockStatic(GitHub.class);
-        PowerMockito.when(GitHub.connectUsingOAuth("https://api.github.com", "accessToken")).thenReturn(gh);
+        PowerMockito.mockStatic(GitHubBuilder.class);
+        PowerMockito.when(GitHubBuilder.fromEnvironment()).thenReturn(builder);
+        PowerMockito.when(builder.withEndpoint("https://api.github.com")).thenReturn(builder);
+        PowerMockito.when(builder.withOAuthToken("accessToken")).thenReturn(builder);
+        PowerMockito.when(builder.withRateLimitHandler(RateLimitHandler.FAIL)).thenReturn(builder);
+        PowerMockito.when(builder.build()).thenReturn(gh);
         GHMyself me = PowerMockito.mock(GHMyself.class);
         PowerMockito.when(gh.getMyself()).thenReturn((GHMyself) me);
         PowerMockito.when(me.getLogin()).thenReturn(username);


### PR DESCRIPTION
Requires #62 to be merged.

We see a lot of errors such as https://gist.github.com/michaelneale/d471fd6c1d44f29b94fe380ced8539d1 

The Github client should always fail fast so that it never locks up web threads and cause Jenkins to become unresponsive.

PTAL @samrocketman 