### PR TITLE
Cache user lookups

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -38,7 +38,6 @@ import hudson.Util;
 import hudson.model.Descriptor;
 import hudson.model.User;
 import hudson.security.GroupDetails;
-import hudson.security.Permission;
 import hudson.security.SecurityRealm;
 import hudson.security.UserMayOrMayNotExistException;
 import hudson.tasks.Mailer;


### PR DESCRIPTION
Requires #63 to be merged.

Introduces a cache for GHUser lookups. This should dramatically reduce the amount of API calls to Github.

PTAL @samrocketman 