### PR TITLE
[JENKINS-40201] Fix cached users breaking authz

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,21 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <powermock.version>1.6.5</powermock.version>
     </properties>
+    <profiles>
+        <!--
+          http://stackoverflow.com/a/26806103/1857257
+          Disable doclint only on JDK8+ where the option was introduced.
+        -->
+		<profile>
+			<id>doclint-java8-disable</id>
+			<activation>
+				<jdk>[1.8,)</jdk>
+			</activation>
+			<properties>
+				<javadoc.opts>-Xdoclint:none</javadoc.opts>
+			</properties>
+		</profile>
+	</profiles>
 
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>github-oauth</artifactId>
@@ -139,7 +154,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <additionalparam>${javadoc.opts}</additionalparam>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
@@ -314,13 +314,13 @@ public class GithubAuthenticationToken extends AbstractAuthenticationToken {
     public GHUser loadUser(String username) throws IOException {
         GithubUser user;
         try {
-            user = usersByIdCache.get(username);
+            user = usersByIdCache.getIfPresent(username);
             if (gh != null && user == null && isAuthenticated()) {
                 GHUser ghUser = getGitHub().getUser(username);
                 user = new GithubUser(ghUser);
                 usersByIdCache.put(username, user);
             }
-        } catch (IOException | ExecutionException e) {
+        } catch (IOException e) {
             LOGGER.log(Level.FINEST, e.getMessage(), e);
             user = UNKNOWN_USER;
             usersByIdCache.put(username, UNKNOWN_USER);


### PR DESCRIPTION
for GitHub organizations being used as a group in Jenkins.

Fixed bug introduced by #64.

See https://issues.jenkins-ci.org/browse/JENKINS-40201

Please take a look @i386.