### PR TITLE
Fix for NPE in GithubOAuthUserDetails.getAuthorities()

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubOAuthUserDetails.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubOAuthUserDetails.java
@@ -42,7 +42,9 @@ public class GithubOAuthUserDetails extends User implements UserDetails {
         if (!hasGrantedAuthorities) {
             try {
                 GHUser user = authenticationToken.loadUser(getUsername());
-                setAuthorities(authenticationToken.getGrantedAuthorities(user));
+                if(user != null) {
+                    setAuthorities(authenticationToken.getGrantedAuthorities(user));
+                }
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
There is missing null check in GithubOAuthUserDetails.getAuthorities(). NPE can happen if `authenticationToken.loadUser(getUsername());` returns null.

To reproduce NPE:

- Install github-oauth plugin and GitHub authentication and authorization are enabled.
- Login in to Jenkins (it should log you in using your GitHub user).  
- Assuming you have another user in Jenkins, try impersonating him. e.g. running this script causes NPE:

```
User user = Jenkins.getInstance().getUser("otherUser")
user.impersonate()
```

```
java.lang.NullPointerException
	at org.jenkinsci.plugins.GithubAuthenticationToken.getGrantedAuthorities(GithubAuthenticationToken.java:388)
	at org.jenkinsci.plugins.GithubOAuthUserDetails.getAuthorities(GithubOAuthUserDetails.java:45)
	at hudson.model.User.impersonate(User.java:317)
```

Reported in this BlueOcean ticket: https://issues.jenkins-ci.org/browse/JENKINS-42006.

