### PR TITLE
[JENKINS-27045] Jenkins CLI --username/--password options

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Xmx256m -XX:MaxPermSize=128m -Djava.awt.headless=true

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,7 +2,8 @@ The MIT License
 
 Copyright (c) 2011 Michael O'Cleirigh
 Copyright (c) 2013-2014 Sam Kottler
-Copyright (c) 2015 Sam Gleske
+Copyright (c) 2015-2017 Sam Gleske
+Copyright (c) 2004-, Kohsuke Kawaguchi, Sun Microsystems, Inc., and a number of other of contributors - https://github.com/jenkinsci/jenkins
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/jenkinsci/plugins/GithubSecurityRealmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubSecurityRealmTest.java
@@ -25,7 +25,7 @@ THE SOFTWARE.
 package org.jenkinsci.plugins;
 
 import org.jenkinsci.plugins.GithubSecurityRealm.DescriptorImpl;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
@@ -35,8 +35,8 @@ import static org.junit.Assert.assertTrue;
 
 public class GithubSecurityRealmTest {
 
-    @Rule
-    public final JenkinsRule rule = new JenkinsRule();
+    @ClassRule
+    public final static JenkinsRule rule = new JenkinsRule();
 
     @Test
     public void testEquals_true() {


### PR DESCRIPTION
Here's an example:

    java -jar jenkins-cli.jar -s http://localhost:8080 -noKeyAuth who-am-i --username samrocketman --password-file ./personal-access-token

Unfortunately, Jenkins core prevents Jenkins CLI LoginCommand from working correctly because it only stores the Username and mishandles creating the authentication token.  This is a [bug in core][1].

[1]: https://github.com/jenkinsci/jenkins/blob/jenkins-2.47/core/src/main/java/hudson/cli/ClientAuthenticationCache.java#L65-L75