### PR TITLE
[JENKINS-40566] Allow collaborators to cancel/abort a build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
@@ -260,7 +260,8 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
                 if (permission.equals(Item.READ) ||
                         permission.equals(Item.CONFIGURE) ||
                         permission.equals(Item.DELETE) ||
-                        permission.equals(Item.EXTENDED_READ)) {
+                        permission.equals(Item.EXTENDED_READ) ||
+                        permission.equals(Item.CANCEL)) {
                     return true;
                 } else {
                     return false;

--- a/src/main/webapp/help/auth/use-repository-permissions-help.html
+++ b/src/main/webapp/help/auth/use-repository-permissions-help.html
@@ -1,7 +1,7 @@
 <div>
 If checked will use github repository permissions to determine jenkins permissions for each project.
 <ul>
-    <li>Public projects - all authenticated users can READ. Only collaborators can BUILD, EDIT, CONFIGURE or DELETE.
-    <li>Private projects, only collaborators can READ, BUILD, EDIT, CONFIGURE or DELETE
+    <li>Public projects - all authenticated users can READ. Only collaborators can BUILD, EDIT, CONFIGURE, CANCEL or DELETE.
+    <li>Private projects, only collaborators can READ, BUILD, EDIT, CONFIGURE, CANCEL or DELETE
 </ul>
 </div>

--- a/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
@@ -463,6 +463,7 @@ public class GithubRequireOrganizationMembershipACLTest extends TestCase {
         assertTrue(acl.hasPermission(authenticationToken, Item.CONFIGURE));
         assertTrue(acl.hasPermission(authenticationToken, Item.DELETE));
         assertTrue(acl.hasPermission(authenticationToken, Item.EXTENDED_READ));
+        assertTrue(acl.hasPermission(authenticationToken, Item.CANCEL));
     }
 
     @Test
@@ -480,6 +481,7 @@ public class GithubRequireOrganizationMembershipACLTest extends TestCase {
         assertFalse(acl.hasPermission(authenticationToken, Item.CONFIGURE));
         assertFalse(acl.hasPermission(authenticationToken, Item.DELETE));
         assertFalse(acl.hasPermission(authenticationToken, Item.EXTENDED_READ));
+        assertFalse(acl.hasPermission(authenticationToken, Item.CANCEL));
     }
 
     @Test


### PR DESCRIPTION
Given that collaborators can already carry out destructive tasks (DELETE and CONFIGURE), I see no reason they should not be able to cancel running builds. This is something which is essential in our organisation. Hopefully useful to some other users.