### PR TITLE
[JENKINS-43822] delegates CLI auth to super when no username is passed

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -520,8 +520,7 @@ public class GithubSecurityRealm extends AbstractPasswordBasedSecurityRealm impl
 
             public Authentication authenticate() throws AuthenticationException, IOException, InterruptedException {
                 if(userName == null) {
-                    //return command.getTransportAuthentication();    // no authentication parameter. fallback to the transport
-                    return Jenkins.ANONYMOUS;
+                    super.authenticate();
                 }
                 if(passwordFile != null) {
                     try {


### PR DESCRIPTION
See [JENKINS-43822] https://issues.jenkins-ci.org/browse/JENKINS-43822

This commit delegates CLI auth to super when no username is passed to the overriding method.

Since the immediate bug is that CLI behavior is not preserved, and the existing method override assumes that username is passed as to the CLI, this patch merely delegates to the superclass when that required username is not provided.

I don't feel this is an ideal solution to the override-delegate issue.  The overriding method could attempt to obtain GitHub OAuth authentication by meeting requirements, then delegate to the superclass method if OAuth didn't return credentials.

note: I have no idea how to create an environment to test this, so another set of eyes would be muchly appreciated!  😃 