### PR TITLE
[JENKINS-43822] Fix Jenkins CLI transport auth

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -520,8 +520,8 @@ public class GithubSecurityRealm extends AbstractPasswordBasedSecurityRealm impl
 
             public Authentication authenticate() throws AuthenticationException, IOException, InterruptedException {
                 if(userName == null) {
-                    //return command.getTransportAuthentication();    // no authentication parameter. fallback to the transport
-                    return Jenkins.ANONYMOUS;
+                    // no authentication parameter. fallback to the transport
+                    return command.getTransportAuthentication();
                 }
                 if(passwordFile != null) {
                     try {


### PR DESCRIPTION
This fixes using authentication in the following ways:

- HTTP transport auth.
- SSH authentication.

Example of the fixed behavior:

```
$ java -jar jenkins-cli.jar -s http://localhost:8080/ -http -auth samrocketman:[REDACTED personal access token] who-am-i
Authenticated as: samrocketman
Authorities:
  authenticated
  jenkinsci
  jenkinsci*Everyone
  sandscape
  kata-seeds
  kata-seeds*Groovy
  Gitorious-backup
  Gitorious-backup*Owners
  gimp-ci
  gimp-ci*developers

$ java -jar jenkins-cli.jar -s http://localhost:8080 -i ./id_rsa -ssh -user samrocketman who-am-i
Authenticated as: samrocketman
Authorities:
  authenticated
```

For my tests, I generated a GitHub personal access token with [`read:org` and `user:email` scopes](https://developer.github.com/v3/oauth/#scopes).