### PR TITLE
JENKINS-45726 Corrected a connectivity error on auth with proxy

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
@@ -194,14 +194,14 @@ public class GithubAuthenticationToken extends AbstractAuthenticationToken {
     public GitHub getGitHub() throws IOException {
         if (this.gh == null) {
         	
-        	String host;
+            String host;
             try {
                 host = new URL(this.githubServer).getHost();
             } catch (MalformedURLException e) {
                 throw new IOException("Invalid GitHub API URL: " + this.githubServer, e);
             }
         	
-        	OkHttpClient client = new OkHttpClient().setProxy(getProxy(host));
+            OkHttpClient client = new OkHttpClient().setProxy(getProxy(host));
 
             this.gh = GitHubBuilder.fromEnvironment()
                     .withEndpoint(this.githubServer)

--- a/src/test/java/org/jenkinsci/plugins/GithubAuthenticationTokenTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubAuthenticationTokenTest.java
@@ -10,7 +10,9 @@ import org.kohsuke.github.GHMyself;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
 import org.kohsuke.github.RateLimitHandler;
+import org.kohsuke.github.extras.OkHttpConnector;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -63,6 +65,7 @@ public class GithubAuthenticationTokenTest {
         PowerMockito.when(builder.withEndpoint("https://api.github.com")).thenReturn(builder);
         PowerMockito.when(builder.withOAuthToken("accessToken")).thenReturn(builder);
         PowerMockito.when(builder.withRateLimitHandler(RateLimitHandler.FAIL)).thenReturn(builder);
+        PowerMockito.when(builder.withConnector(Mockito.any(OkHttpConnector.class))).thenReturn(builder);
         PowerMockito.when(builder.build()).thenReturn(gh);
         GHMyself me = PowerMockito.mock(GHMyself.class);
         PowerMockito.when(gh.getMyself()).thenReturn(me);

--- a/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
@@ -51,7 +51,9 @@ import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
 import org.kohsuke.github.PagedIterable;
 import org.kohsuke.github.RateLimitHandler;
+import org.kohsuke.github.extras.OkHttpConnector;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -176,6 +178,7 @@ public class GithubRequireOrganizationMembershipACLTest extends TestCase {
         PowerMockito.when(builder.withEndpoint("https://api.github.com")).thenReturn(builder);
         PowerMockito.when(builder.withOAuthToken("accessToken")).thenReturn(builder);
         PowerMockito.when(builder.withRateLimitHandler(RateLimitHandler.FAIL)).thenReturn(builder);
+        PowerMockito.when(builder.withConnector(Mockito.any(OkHttpConnector.class))).thenReturn(builder);
         PowerMockito.when(builder.build()).thenReturn(gh);
         GHMyself me = PowerMockito.mock(GHMyself.class);
         PowerMockito.when(gh.getMyself()).thenReturn((GHMyself) me);


### PR DESCRIPTION
On the GithubAuthenticationToken the GitHub instance was created without the proxy information.
That causes authentication errors when there's a network proxy.