### PR TITLE
Potential bug in access_token retrieval method

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -426,7 +426,7 @@ public class GithubSecurityRealm extends AbstractPasswordBasedSecurityRealm impl
         }
         String parts[] = content.split("&");
         for (String part : parts) {
-            if (content.contains("access_token")) {
+            if (part.startsWith("access_token=")) {
                 String tokenParts[] = part.split("=");
                 return tokenParts[1];
             }


### PR DESCRIPTION
- currently it's working due to 2 facts
  - the keys are alphabetically ordered and for the moment `access_token` is the first one
  - there is no key containing access_token like `optional_access_token` or `access_token_primary`
- this modification will prevent change in the key set to affect our retrieval technique

See [JENKINS-48081](https://issues.jenkins-ci.org/browse/JENKINS-48081).

@reviewbybees 