### PR TITLE
[JENKINS-42509] authenticated team members should have read/build permissions when using Github Committer Authorization Strategy

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
@@ -273,7 +273,7 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
                 authenticationToken.isPublicRepository(repositoryName)) {
             return true;
         } else {
-            return authenticationToken.hasRepositoryPermission(repositoryName);
+            return authenticationToken.hasRepositoryPermission(repositoryName, permission);
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -106,7 +106,7 @@ public class GithubSecurityRealm extends AbstractPasswordBasedSecurityRealm impl
     private static final String DEFAULT_WEB_URI = "https://github.com";
     private static final String DEFAULT_API_URI = "https://api.github.com";
     private static final String DEFAULT_ENTERPRISE_API_SUFFIX = "/api/v3";
-    private static final String DEFAULT_OAUTH_SCOPES = "read:org,user:email";
+    private static final String DEFAULT_OAUTH_SCOPES = "read:org,user:email,repo";
 
     private String githubWebUri;
     private String githubApiUri;
@@ -551,7 +551,7 @@ public class GithubSecurityRealm extends AbstractPasswordBasedSecurityRealm impl
     @Override
     protected String getPostLogOutUrl(StaplerRequest req, Authentication auth) {
         // if we just redirect to the root and anonymous does not have Overall read then we will start a login all over again.
-        // we are actually anonymous here as the security context has been cleared 
+        // we are actually anonymous here as the security context has been cleared
         Jenkins j = Jenkins.getInstance();
         assert j != null;
         if (j.hasPermission(Jenkins.READ)) {

--- a/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
@@ -103,7 +103,9 @@ public class GithubRequireOrganizationMembershipACLTest extends TestCase {
         PowerMockito.mockStatic(Jenkins.class);
         PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
         PowerMockito.when(jenkins.getSecurityRealm()).thenReturn(securityRealm);
-        PowerMockito.when(securityRealm.getOauthScopes()).thenReturn("read:org");
+        PowerMockito.when(securityRealm.getOauthScopes()).thenReturn("read:org,repo");
+        PowerMockito.when(securityRealm.hasScope("read:org")).thenReturn(true);
+        PowerMockito.when(securityRealm.hasScope("repo")).thenReturn(true);
     }
 
     private static final Permission VIEW_JOBSTATUS_PERMISSION = new Permission(Item.PERMISSIONS,

--- a/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
@@ -92,6 +92,8 @@ public class GithubRequireOrganizationMembershipACLTest extends TestCase {
     @Mock
     private Jenkins jenkins;
 
+    private GitHub gh;
+
     @Mock
     private GithubSecurityRealm securityRealm;
 
@@ -170,7 +172,7 @@ public class GithubRequireOrganizationMembershipACLTest extends TestCase {
     }
 
     private GHMyself mockGHMyselfAs(String username) throws IOException {
-        GitHub gh = PowerMockito.mock(GitHub.class);
+        gh = PowerMockito.mock(GitHub.class);
         GitHubBuilder builder = PowerMockito.mock(GitHubBuilder.class);
         PowerMockito.mockStatic(GitHub.class);
         PowerMockito.mockStatic(GitHubBuilder.class);
@@ -264,14 +266,6 @@ public class GithubRequireOrganizationMembershipACLTest extends TestCase {
         return multiBranchProject;
     }
 
-    private void mockGithubRepositoryWithCollaborators(GitHub mockGithub, String name, boolean isPrivate, List<String> collaboratorNames) throws IOException {
-        GHRepository ghRepository = PowerMockito.mock(GHRepository.class);
-        PowerMockito.when(mockGithub.getRepository(name)).thenReturn(ghRepository);
-        PowerMockito.when(ghRepository.isPrivate()).thenReturn(isPrivate);
-        Set<String> names = new HashSet(collaboratorNames);
-        PowerMockito.when(ghRepository.getCollaboratorNames()).thenReturn(names);
-    }
-
     @Test
     public void testCanReadAndBuildOneOfMyRepositories() throws IOException {
         GHMyself me = mockGHMyselfAs("Me");
@@ -296,6 +290,7 @@ public class GithubRequireOrganizationMembershipACLTest extends TestCase {
 
     @Override
     protected void tearDown() throws Exception {
+        gh = null;
         super.tearDown();
         GithubAuthenticationToken.clearCaches();
     }
@@ -306,6 +301,37 @@ public class GithubRequireOrganizationMembershipACLTest extends TestCase {
         mockReposFor(me, Arrays.asList("me/a-repo"));
         mockOrgRepos(me, ImmutableMap.of("some-org", Arrays.asList("some-org/a-private-repo")));
         String repoUrl = "https://github.com/some-org/a-private-repo.git";
+        Project mockProject = mockProject(repoUrl);
+        MultiBranchProject mockMultiBranchProject = mockMultiBranchProject(repoUrl);
+        WorkflowJob mockWorkflowJob = mockWorkflowJob(repoUrl);
+        GithubRequireOrganizationMembershipACL workflowJobAcl = aclForWorkflowJob(mockWorkflowJob);
+        GithubRequireOrganizationMembershipACL multiBranchProjectAcl = aclForMultiBranchProject(mockMultiBranchProject);
+        GithubRequireOrganizationMembershipACL projectAcl = aclForProject(mockProject);
+
+        GithubAuthenticationToken authenticationToken = new GithubAuthenticationToken("accessToken", "https://api.github.com");
+
+        assertTrue(projectAcl.hasPermission(authenticationToken, Item.READ));
+        assertTrue(projectAcl.hasPermission(authenticationToken, Item.BUILD));
+        assertTrue(multiBranchProjectAcl.hasPermission(authenticationToken, Item.READ));
+        assertTrue(multiBranchProjectAcl.hasPermission(authenticationToken, Item.BUILD));
+        assertTrue(workflowJobAcl.hasPermission(authenticationToken, Item.READ));
+        assertTrue(workflowJobAcl.hasPermission(authenticationToken, Item.BUILD));
+    }
+
+    @Test
+    public void testCanReadAndBuildOtherOrgPrivateRepositoryICollaborateOn() throws IOException {
+        GHMyself me = mockGHMyselfAs("Me");
+        mockReposFor(me, Arrays.asList("me/a-repo"));
+        mockOrgRepos(me, ImmutableMap.of("some-org", Arrays.asList("some-org/a-private-repo")));
+        GHRepository ghRepository = PowerMockito.mock(GHRepository.class);
+        PowerMockito.when(gh.getRepository("org-i-dont-belong-to/a-private-repo-i-collaborate-on")).thenReturn(ghRepository);
+        PowerMockito.when(ghRepository.isPrivate()).thenReturn(true);
+        PowerMockito.when(ghRepository.hasAdminAccess()).thenReturn(false);
+        PowerMockito.when(ghRepository.hasPushAccess()).thenReturn(false);
+        PowerMockito.when(ghRepository.hasPullAccess()).thenReturn(true);
+
+        // The user isn't part of "org-i-dont-belong-to"
+        String repoUrl = "https://github.com/org-i-dont-belong-to/a-private-repo-i-collaborate-on.git";
         Project mockProject = mockProject(repoUrl);
         MultiBranchProject mockMultiBranchProject = mockMultiBranchProject(repoUrl);
         WorkflowJob mockWorkflowJob = mockWorkflowJob(repoUrl);

--- a/src/test/java/org/jenkinsci/plugins/GithubSecurityRealmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubSecurityRealmTest.java
@@ -82,6 +82,6 @@ public class GithubSecurityRealmTest {
     @Test
     public void testDescriptorImplGetDefaultOauthScopes() {
         DescriptorImpl descriptor = new DescriptorImpl();
-        assertTrue("read:org,user:email".equals(descriptor.getDefaultOauthScopes()));
+        assertTrue("read:org,user:email,repo".equals(descriptor.getDefaultOauthScopes()));
     }
 }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-42509

On private repositories of which the user is not an owner, not a member of the owning organization - check for admin/push/pull permissions on the repository to determine permissions on the Jenkins item.