### PR TITLE
Cache User (1 min) and Teams (1 hour) information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.30
+
+- Enabled Cache for User Teams. (pull request [#100])
+
 # Version 0.29 (Released Jan 22, 2018)
 
 - New feature: When users authorize OAuth apps from GitHub the token is now

--- a/src/test/java/org/jenkinsci/plugins/GithubAccessTokenPropertyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubAccessTokenPropertyTest.java
@@ -305,6 +305,8 @@ public class GithubAccessTokenPropertyTest {
         // request whoAmI with GitHubToken => group populated
         makeRequestWithAuthCodeAndVerify(encodeBasic(aliceLogin, aliceGitHubToken), "alice", Arrays.asList("authenticated", "org-a", "org-a*team-b"));
 
+        GithubAuthenticationToken.clearCaches();
+
         // no authentication in session but use the cache
         makeRequestWithAuthCodeAndVerify(encodeBasic(aliceLogin, aliceApiRestToken), "alice", Arrays.asList("authenticated", "org-a", "org-a*team-b"));
 
@@ -333,6 +335,7 @@ public class GithubAccessTokenPropertyTest {
         // request whoAmI with ApiRestToken => group populated (due to login event)
         makeRequestWithAuthCodeAndVerify(encodeBasic(bobLogin, bobApiRestToken), "bob", Arrays.asList("authenticated", "org-c", "org-c*team-d"));
 
+        GithubAuthenticationToken.clearCaches();
         wc = j.createWebClient();
         // retrieve the security group even without the cookie (using LastGrantedAuthorities this time)
         makeRequestWithAuthCodeAndVerify(encodeBasic(bobLogin, bobApiRestToken), "bob", Arrays.asList("authenticated", "org-c", "org-c*team-d"));


### PR DESCRIPTION
# Changes
The goal of this PR is to reduce requests rate to GitHub API by additional caching: 

* access token -> user info for a minute;
* GH user -> teams info for an hour.

# Rationale
If you have a service/bot which uses Jenkins and it makes a lot of API calls, fixed GitHub requests rate may quickly become a bottleneck. 

# Note
It's my first code written in Java, but I was able to compile it and test with Jenkins `2.107.1` :) 
It works fine for our organization and helped us to dramatically decrease requests rate (approximately 10x times), that Jenkins makes to GitHub while authenticating API requests from our bot (just in case it uses `python-jenkins` client).

# Call for HELP!
I'd really appreciate if someone helps me to _groom_ the code and add/fix tests! 

P.S.: I could miss something fundamental, so please share your thoughts on the issue I described and am trying to fix! Thank you!

