### PR TITLE
Fix for [JENKINS-54031] GitHub OAuth plugin fails with Jenkins 2.146

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
@@ -401,7 +401,9 @@ public class GithubAuthenticationToken extends AbstractAuthenticationToken {
           return true;
         }
         // WRITE or READ can Read/Build/View Workspace/Discover
-        if (checkImpliedPermission(Permission.READ, permission) || checkImpliedPermission(Item.BUILD, permission)) {
+        if (checkImpliedPermission(Item.READ, permission)
+          || checkImpliedPermission(Item.BUILD, permission)
+          || checkImpliedPermission(Item.WORKSPACE, permission)) {
           return repository.hasPullAccess() || repository.hasPushAccess();
         }
         // WRITE can cancel builds


### PR DESCRIPTION
**JIRA**: https://issues.jenkins-ci.org/browse/JENKINS-54031

This is an attempt to fix permissions issues introduced in the last LTS patch release of Jenkins. According to comments from @daniel-beck it appears this plugin isn't handling `Item.DISCOVER` permissions properly as a sub-set of `READ`.

I tried to clean up the code a little to make it easier to follow; add some tests around anonymous reads of the github-webhook and cc tray; make use of the `Permission.impliedBy` property to iterate up the hierarchy.

The notable change in behavior here is that this now treats DISCOVER permissions request like READ; users with write access to a repo can still cancel builds, but cannot view configuration anymore.

I'm not entirely sure if this changes actual behavior/rights for users when "allowing authenticated user to create jobs" - I think it now limits permissions solely to Item.CREATE when there's no repository name (whereas before it allowed read/configure/delete/view config/cancel). I'm not sure what's the right permission set to allow in this case, maybe if an authenticated user can create jobs they should have rights to CREATE/CONFIGURE/EXTENDED_READ/DELETE for all jobs too?