### PR TITLE
Reduce API calls

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
@@ -407,15 +407,10 @@ public class GithubAuthenticationToken extends AbstractAuthenticationToken {
                 new Callable<Set<String>>() {
                     @Override
                     public Set<String> call() throws Exception {
-                        List<GHRepository> userRepositoryList = getMyself().listRepositories().asList();
-                        Set<String> repositoryNames = listToNames(userRepositoryList);
-                        GHPersonSet<GHOrganization> organizations = getMyself().getAllOrganizations();
-                        for (GHOrganization organization : organizations) {
-                            List<GHRepository> orgRepositoryList = organization.listRepositories().asList();
-                            Set<String> orgRepositoryNames = listToNames(orgRepositoryList);
-                            repositoryNames.addAll(orgRepositoryNames);
-                        }
-                        return repositoryNames;
+                        // listRepositories returns all repos owned by user, where they are a collaborator,
+                        //  and any user has access through org membership
+                        List<GHRepository> userRepositoryList = getMyself().listRepositories(100).asList(); // use max page size of 100 to limit API calls
+                        return listToNames(userRepositoryList);
                     }
                 }
             );
@@ -429,9 +424,7 @@ public class GithubAuthenticationToken extends AbstractAuthenticationToken {
     public Set<String> listToNames(Collection<GHRepository> respositories) throws IOException {
         Set<String> names = new HashSet<String>();
         for (GHRepository repository : respositories) {
-            String ownerName = repository.getOwner().getLogin();
-            String repoName = repository.getName();
-            names.add(ownerName + "/" + repoName);
+            names.add(repository.getFullName());
         }
         return names;
     }


### PR DESCRIPTION
- Ask for max 100 entries of repositories per page for user. (default was 30)
- Don't loop through orgs after as the info is redundant (`listRepositories()` includes repos user can access through org membership).
- Also when constructing repo names, use `#getFullName()`, rather than `#getOwner().getLogin()` as that may result in another API call.