### PR TITLE
[JENKINS-55557] Add support for state parameter

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/GithubAccessTokenPropertySEC797Test.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubAccessTokenPropertySEC797Test.java
@@ -249,7 +249,8 @@ public class GithubAccessTokenPropertySEC797Test {
         
         private void onLoginOAuthAuthorize(HttpServletRequest req, HttpServletResponse resp) throws IOException {
             String code = "test";
-            resp.sendRedirect(jenkinsRule.getURL() + "securityRealm/finishLogin?code=" + code);
+            String state = req.getParameter("state");
+            resp.sendRedirect(jenkinsRule.getURL() + "securityRealm/finishLogin?code=" + code + "&state=" + state);
         }
         
         private void onLoginOAuthAccessToken(HttpServletRequest req, HttpServletResponse resp) throws IOException {

--- a/src/test/java/org/jenkinsci/plugins/GithubAccessTokenPropertyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubAccessTokenPropertyTest.java
@@ -246,7 +246,7 @@ public class GithubAccessTokenPropertyTest {
         private void onLoginOAuthAuthorize(HttpServletRequest req, HttpServletResponse resp) throws IOException {
             String code = "test";
             String state = req.getParameter("state");
-            resp.sendRedirect(jenkinsRule.getURL() + "securityRealm/finishLogin?code=" + code+"&state="+state);
+            resp.sendRedirect(jenkinsRule.getURL() + "securityRealm/finishLogin?code=" + code + "&state=" + state);
         }
 
         private void onLoginOAuthAccessToken(HttpServletRequest req, HttpServletResponse resp) throws IOException {

--- a/src/test/java/org/jenkinsci/plugins/GithubAccessTokenPropertyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubAccessTokenPropertyTest.java
@@ -245,7 +245,8 @@ public class GithubAccessTokenPropertyTest {
 
         private void onLoginOAuthAuthorize(HttpServletRequest req, HttpServletResponse resp) throws IOException {
             String code = "test";
-            resp.sendRedirect(jenkinsRule.getURL() + "securityRealm/finishLogin?code=" + code);
+            String state = req.getParameter("state");
+            resp.sendRedirect(jenkinsRule.getURL() + "securityRealm/finishLogin?code=" + code+"&state="+state);
         }
 
         private void onLoginOAuthAccessToken(HttpServletRequest req, HttpServletResponse resp) throws IOException {


### PR DESCRIPTION
Use of state parameter [1] when using the authorization code grant
flow of oAuth2, mitigates CSRF attacks as described in "OAuth 2.0 
Threat Model and Security Considerations" [2]


[1] https://tools.ietf.org/html/rfc6749#section-4.1.1
[2] https://tools.ietf.org/html/rfc6819#section-4.4.1.8