### PR TITLE
compatible-since-version was set incorrectly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
                 <version>1.109</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <compatibleSinceVersion>1.93</compatibleSinceVersion>
+                    <compatibleSinceVersion>0.3</compatibleSinceVersion>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
v0.31 being compatible with all versions of this plugin since v1.93 doesn't make any sense ;-)

It looks like this value was changed by mistake in https://github.com/jenkinsci/github-oauth-plugin/commit/2f0985e5666c59991b8041cb099bc3c3e5e48926

Setting it back to its original version.