### PR TITLE
[JENKINS-56229] Use the correct access token when impersonating a user

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -659,7 +659,7 @@ public class GithubSecurityRealm extends AbstractPasswordBasedSecurityRealm impl
 
         Authentication token = SecurityContextHolder.getContext().getAuthentication();
 
-        if (token == null || username != token.getPrincipal()) {
+        if (token == null || !username.equals(token.getPrincipal())) {
             if(localUser != null && GithubSecretStorage.contains(localUser)){
                 String accessToken = GithubSecretStorage.retrieve(localUser);
                 try {

--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -659,7 +659,7 @@ public class GithubSecurityRealm extends AbstractPasswordBasedSecurityRealm impl
 
         Authentication token = SecurityContextHolder.getContext().getAuthentication();
 
-        if (token == null) {
+        if (token == null || username != token.getPrincipal()) {
             if(localUser != null && GithubSecretStorage.contains(localUser)){
                 String accessToken = GithubSecretStorage.retrieve(localUser);
                 try {


### PR DESCRIPTION
The token retrieved will be for the caller of the user.impersonate()
method (ie, could be SYSTEM), rather than that of the target of the
impersonation.

@reviewbybees 