### PR TITLE
[JENKINS-51657] Allow restricting authentication to organizations

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
@@ -219,22 +219,8 @@ public class GithubAuthenticationToken extends AbstractAuthenticationToken {
 
         Set<String> authorizedOrgs = myRealm.getAuthorizedOrganizations();
         if (authorizedOrgs.size() > 0) {
-            boolean canReadOrgs = myRealm.hasScope("user") || myRealm.hasScope("read:user");
-            if (!canReadOrgs) {
-                return;
-            }
-            Set<String> myOrgs;
-            try {
-                myOrgs = getUserOrgs();
-            } catch (ExecutionException e) {
-                throw new RuntimeException("authorization failed for user = "
-                                           + getName(), e);
-            }
-
             // Check if user has some intersection with authorized orgs
-            Set<String> orgsIntersection = new HashSet<>(authorizedOrgs);
-            orgsIntersection.retainAll(myOrgs);
-            if(orgsIntersection.size() == 0){
+            if (!isMemberOfAnyOrganizationInList(authorizedOrgs)) {
                 return;
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/GithubUnauthorizedAction.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubUnauthorizedAction.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 Michael Beaumont
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins;
+
+import hudson.Extension;
+import hudson.model.UnprotectedRootAction;
+
+/**
+ * A page that shows a simple message when the user is not at all authorized.
+ * This prevents a logout -> login loop when using this security realm and Anonymous does not have {@code Overall.READ} permission.
+ */
+@Extension
+public class GithubUnauthorizedAction implements UnprotectedRootAction {
+
+    /** The URL of the action. */
+    static final String UNAUTHORIZED_URL = "githubUnauthorized";
+
+    @Override
+    public String getDisplayName() {
+        return "Github Unauthorized";
+    }
+
+    @Override
+    public String getIconFileName() {
+        // hide it
+        return null;
+    }
+
+    @Override
+    public String getUrlName() {
+        return UNAUTHORIZED_URL;
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/GithubSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/GithubSecurityRealm/config.jelly
@@ -23,5 +23,9 @@
         <f:entry title="OAuth Scope(s)" field="oauthScopes" help="/plugin/github-oauth/help/realm/oauth-scopes-help.html">
             <f:textbox default="${descriptor.getDefaultOauthScopes()}" />
         </f:entry>
+
+        <f:entry title="Authorized organizations" field="authorizedOrganizationsString" help="/plugin/github-oauth/help/realm/authorized-organizations.html">
+            <f:textbox default="${descriptor.getDefaultAuthorizedOrganizationString()}" />
+        </f:entry>
     </f:section>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/GithubUnauthorizedAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/GithubUnauthorizedAction/index.jelly
@@ -1,0 +1,41 @@
+<!--
+ The MIT License
+
+ Copyright (c) 2019 Michael Beaumont
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+  <l:layout norefresh="true">
+    <l:main-panel>
+      <j:choose>
+        <j:when test="${h.isAnonymous()}">
+          <p>Your GitHub account is not authorized to log into Jenkins.</p>
+          <p>Have a nice day!</p>
+        </j:when>
+        <j:otherwise>
+          <h2>Whoa there...</h2>
+          <p>You are actually authorized - don't run away!</p>
+        </j:otherwise>
+      </j:choose>
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/src/main/webapp/help/realm/authorized-organizations.html
+++ b/src/main/webapp/help/realm/authorized-organizations.html
@@ -1,0 +1,3 @@
+<div>
+A comma separated list of GitHub Organizations to restrict access to.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/GithubAccessTokenPropertySEC797Test.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubAccessTokenPropertySEC797Test.java
@@ -270,13 +270,15 @@ public class GithubAccessTokenPropertySEC797Test {
         String clientID = "xxx";
         String clientSecret = "yyy";
         String oauthScopes = "read:org";
+        String authorizedOrgs = "";
         
         GithubSecurityRealm githubSecurityRealm = new GithubSecurityRealm(
                 githubWebUri,
                 githubApiUri,
                 clientID,
                 clientSecret,
-                oauthScopes
+                oauthScopes,
+                authorizedOrgs
         );
         
         j.jenkins.setSecurityRealm(githubSecurityRealm);

--- a/src/test/java/org/jenkinsci/plugins/GithubAccessTokenPropertyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubAccessTokenPropertyTest.java
@@ -266,13 +266,15 @@ public class GithubAccessTokenPropertyTest {
         String clientID = "xxx";
         String clientSecret = "yyy";
         String oauthScopes = "read:org";
+        String authorizedOrgs = "";
 
         GithubSecurityRealm githubSecurityRealm = new GithubSecurityRealm(
                 githubWebUri,
                 githubApiUri,
                 clientID,
                 clientSecret,
-                oauthScopes
+                oauthScopes,
+                authorizedOrgs
         );
 
         j.jenkins.setSecurityRealm(githubSecurityRealm);

--- a/src/test/java/org/jenkinsci/plugins/GithubAuthenticationTokenTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubAuthenticationTokenTest.java
@@ -7,6 +7,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kohsuke.github.GHMyself;
+import org.kohsuke.github.GHObject;
+import org.kohsuke.github.GHOrganization;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
 import org.kohsuke.github.RateLimitHandler;
@@ -18,8 +20,15 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({GitHub.class, GitHubBuilder.class, Jenkins.class, GithubSecurityRealm.class})
@@ -30,6 +39,9 @@ public class GithubAuthenticationTokenTest {
 
     @Mock
     private GithubSecurityRealm securityRealm;
+
+    @Mock
+    private GitHub gh;
 
     @Before
     public void setUp() throws Exception {
@@ -51,13 +63,44 @@ public class GithubAuthenticationTokenTest {
         assertEquals(deserializedToken.getMyself().getLogin(), deserializedToken.getMyself().getLogin());
     }
 
+    private void mockAuthorizedOrgs(String org) {
+        Set<String> authorizedOrgs = new HashSet<>(Arrays.asList(org));
+        PowerMockito.when(this.securityRealm.getAuthorizedOrganizations()).thenReturn(authorizedOrgs);
+        PowerMockito.when(this.securityRealm.hasScope("user")).thenReturn(true);
+    }
+
+    private void mockAsInOrg(String org) throws IOException {
+        Map<String, GHOrganization> myOrgs = new HashMap<>();
+        myOrgs.put(org, new GHOrganization());
+        PowerMockito.when(this.gh.getMyOrganizations()).thenReturn(myOrgs);
+    }
+
+    @Test
+    public void testInAuthorizedOrgs() throws IOException {
+        mockGHMyselfAs("bob");
+        mockAuthorizedOrgs("orgA");
+        mockAsInOrg("orgA");
+
+        GithubAuthenticationToken authenticationToken = new GithubAuthenticationToken("accessToken", "https://api.github.com");
+        assertTrue(authenticationToken.isAuthenticated());
+    }
+
+    @Test
+    public void testNotInAuthorizedOrgs() throws IOException {
+        mockGHMyselfAs("bob");
+        mockAuthorizedOrgs("orgA");
+        mockAsInOrg("orgB");
+
+        GithubAuthenticationToken authenticationToken = new GithubAuthenticationToken("accessToken", "https://api.github.com");
+        assertFalse(authenticationToken.isAuthenticated());
+    }
+
     @After
     public void after() {
         GithubAuthenticationToken.clearCaches();
     }
 
     private GHMyself mockGHMyselfAs(String username) throws IOException {
-        GitHub gh = PowerMockito.mock(GitHub.class);
         GitHubBuilder builder = PowerMockito.mock(GitHubBuilder.class);
         PowerMockito.mockStatic(GitHub.class);
         PowerMockito.mockStatic(GitHubBuilder.class);
@@ -66,7 +109,7 @@ public class GithubAuthenticationTokenTest {
         PowerMockito.when(builder.withOAuthToken("accessToken")).thenReturn(builder);
         PowerMockito.when(builder.withRateLimitHandler(RateLimitHandler.FAIL)).thenReturn(builder);
         PowerMockito.when(builder.withConnector(Mockito.any(OkHttpConnector.class))).thenReturn(builder);
-        PowerMockito.when(builder.build()).thenReturn(gh);
+        PowerMockito.when(builder.build()).thenReturn(this.gh);
         GHMyself me = PowerMockito.mock(GHMyself.class);
         PowerMockito.when(gh.getMyself()).thenReturn(me);
         PowerMockito.when(me.getLogin()).thenReturn(username);

--- a/src/test/java/org/jenkinsci/plugins/GithubSecurityRealmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubSecurityRealmTest.java
@@ -29,6 +29,9 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -40,22 +43,22 @@ public class GithubSecurityRealmTest {
 
     @Test
     public void testEquals_true() {
-        GithubSecurityRealm a = new GithubSecurityRealm("http://jenkins.acme.com", "http://jenkins.acme.com/api/v3", "someid", "somesecret", "read:org");
-        GithubSecurityRealm b = new GithubSecurityRealm("http://jenkins.acme.com", "http://jenkins.acme.com/api/v3", "someid", "somesecret", "read:org");
+        GithubSecurityRealm a = new GithubSecurityRealm("http://jenkins.acme.com", "http://jenkins.acme.com/api/v3", "someid", "somesecret", "read:org", "");
+        GithubSecurityRealm b = new GithubSecurityRealm("http://jenkins.acme.com", "http://jenkins.acme.com/api/v3", "someid", "somesecret", "read:org", "");
         assertTrue(a.equals(b));
     }
 
     @Test
     public void testEquals_false() {
-        GithubSecurityRealm a = new GithubSecurityRealm("http://jenkins.acme.com", "http://jenkins.acme.com/api/v3", "someid", "somesecret", "read:org");
-        GithubSecurityRealm b = new GithubSecurityRealm("http://jenkins.acme.com", "http://jenkins.acme.com/api/v3", "someid", "somesecret", "read:org,repo");
+        GithubSecurityRealm a = new GithubSecurityRealm("http://jenkins.acme.com", "http://jenkins.acme.com/api/v3", "someid", "somesecret", "read:org", "");
+        GithubSecurityRealm b = new GithubSecurityRealm("http://jenkins.acme.com", "http://jenkins.acme.com/api/v3", "someid", "somesecret", "read:org,repo", "");
         assertFalse(a.equals(b));
         assertFalse(a.equals(""));
     }
 
     @Test
     public void testHasScope_true() {
-        GithubSecurityRealm a = new GithubSecurityRealm("http://jenkins.acme.com", "http://jenkins.acme.com/api/v3", "someid", "somesecret", "read:org,user,user:email");
+        GithubSecurityRealm a = new GithubSecurityRealm("http://jenkins.acme.com", "http://jenkins.acme.com/api/v3", "someid", "somesecret", "read:org,user,user:email", "");
         assertTrue(a.hasScope("user"));
         assertTrue(a.hasScope("read:org"));
         assertTrue(a.hasScope("user:email"));
@@ -63,8 +66,30 @@ public class GithubSecurityRealmTest {
 
     @Test
     public void testHasScope_false() {
-        GithubSecurityRealm a = new GithubSecurityRealm("http://jenkins.acme.com", "http://jenkins.acme.com/api/v3", "someid", "somesecret", "read:org,user,user:email");
+        GithubSecurityRealm a = new GithubSecurityRealm("http://jenkins.acme.com", "http://jenkins.acme.com/api/v3", "someid", "somesecret", "read:org,user,user:email", "");
         assertFalse(a.hasScope("somescope"));
+    }
+
+    @Test
+    public void testAuthorizedOrganizations_empty() {
+        GithubSecurityRealm a = new GithubSecurityRealm("http://jenkins.acme.com", "http://jenkins.acme.com/api/v3", "someid", "somesecret", "read:org,user,user:email", "");
+        assertEquals(0, a.getAuthorizedOrganizations().size());
+    }
+
+    @Test
+    public void testAuthorizedOrganizations_single() {
+        GithubSecurityRealm a = new GithubSecurityRealm("http://jenkins.acme.com", "http://jenkins.acme.com/api/v3", "someid", "somesecret", "read:org,user,user:email", "org-a");
+        Object[] orgs = a.getAuthorizedOrganizations().toArray();
+        Arrays.sort(orgs);
+        assertEquals(new Object[]{"org-a"}, orgs);
+    }
+
+    @Test
+    public void testAuthorizedOrganizations_multiple() {
+        GithubSecurityRealm a = new GithubSecurityRealm("http://jenkins.acme.com", "http://jenkins.acme.com/api/v3", "someid", "somesecret", "read:org,user,user:email", "org-a,orgB");
+        Object[] orgs = a.getAuthorizedOrganizations().toArray();
+        Arrays.sort(orgs);
+        assertEquals(new Object[]{"org-a", "orgB"}, orgs);
     }
 
     @Test


### PR DESCRIPTION
Includes a new config option to list which organizations a user should be a part of before they can authenticate. When left blank, all organizations can authenticate, keeping the previous behavior.