### PR TITLE
Update log level for private repositories

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
@@ -528,8 +528,8 @@ public class GithubAuthenticationToken extends AbstractAuthenticationToken {
               );
           }
       } catch (Exception e) {
-          LOGGER.log(Level.SEVERE, "an exception was thrown", e);
-          LOGGER.log(Level.WARNING,
+          LOGGER.log(Level.FINEST, "an exception was thrown", e);
+          LOGGER.log(Level.FINEST,
               "Looks like a bad GitHub URL OR the Jenkins user {0} does not have access to the repository {1}. May need to add 'repo' or 'public_repo' to the list of oauth scopes requested.",
               new Object[] { this.userName, repositoryName });
       }


### PR DESCRIPTION
When a Jenkins user does not have access to certain GitHub repositories (for example private repositories), an exception is thrown.
This reduces the log level to FINEST for such condition, as this is a normal behaviour and not a cause of alarm. 
For a Jenkins instance with many private repositories, logs are filled with those errors.

![image](https://user-images.githubusercontent.com/5385290/56145465-a2ac8000-5fa4-11e9-8ffb-b1343716c20a.png)
