### PR TITLE
JENKINS-50122 Fix rights management for workflow jobs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
@@ -102,12 +102,8 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
 
     @Nonnull
     public ACL getACL(@Nonnull Job<?,?> job) {
-        if(job instanceof WorkflowJob && job.getProperty(BranchJobProperty.class) != null || job instanceof AbstractProject) {
-            GithubRequireOrganizationMembershipACL githubACL = (GithubRequireOrganizationMembershipACL) getRootACL();
-            return githubACL.cloneForProject(job);
-        } else {
-            return getRootACL();
-        }
+        GithubRequireOrganizationMembershipACL githubACL = (GithubRequireOrganizationMembershipACL) getRootACL();
+        return githubACL.cloneForProject(job);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
@@ -251,9 +251,12 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
         String repositoryName = null;
         String repoUrl = null;
         Describable scm = null;
+
         if (this.item instanceof WorkflowJob) {
-            WorkflowJob project = (WorkflowJob) item;
-            scm = project.getProperty(BranchJobProperty.class).getBranch().getScm();
+            WorkflowJob job = (WorkflowJob) item;
+            if (! job.getSCMs().isEmpty()) {
+                scm = job.getSCMs().iterator().next();
+            }
         } else if (this.item instanceof MultiBranchProject) {
             MultiBranchProject project = (MultiBranchProject) item;
             scm = (SCMSource) project.getSCMSources().get(0);

--- a/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
@@ -28,6 +28,7 @@ package org.jenkinsci.plugins;
 
 import com.google.common.collect.ImmutableMap;
 
+import hudson.scm.SCM;
 import junit.framework.TestCase;
 
 import org.acegisecurity.Authentication;
@@ -61,13 +62,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import hudson.model.Hudson;
 import hudson.model.Item;
@@ -217,13 +212,15 @@ public class GithubRequireOrganizationMembershipACLTest extends TestCase {
     private WorkflowJob mockWorkflowJob(String url) {
         WorkflowJob project = PowerMockito.mock(WorkflowJob.class);
         GitSCM gitSCM = PowerMockito.mock(GitSCM.class);
-        Branch branch = PowerMockito.mock(Branch.class);
-        BranchJobProperty branchJobProperty = PowerMockito.mock(BranchJobProperty.class);
+        Collection scm = PowerMockito.mock(Collection.class);
+        Iterator it = PowerMockito.mock(Iterator.class);
         UserRemoteConfig userRemoteConfig = PowerMockito.mock(UserRemoteConfig.class);
         List<UserRemoteConfig> userRemoteConfigs = Arrays.asList(userRemoteConfig);
-        PowerMockito.when(project.getProperty(BranchJobProperty.class)).thenReturn(branchJobProperty);
-        PowerMockito.when(branchJobProperty.getBranch()).thenReturn(branch);
-        PowerMockito.when(branch.getScm()).thenReturn(gitSCM);
+
+        PowerMockito.when(project.getSCMs()).thenReturn(scm);
+        PowerMockito.when(scm.isEmpty()).thenReturn(false);
+        PowerMockito.when(scm.iterator()).thenReturn(it);
+        PowerMockito.when(it.next()).thenReturn(gitSCM);
         PowerMockito.when(gitSCM.getUserRemoteConfigs()).thenReturn(userRemoteConfigs);
         PowerMockito.when(userRemoteConfig.getUrl()).thenReturn(url);
         return project;


### PR DESCRIPTION
Workflow jobs does not have the BranchJobProperty set but
multibranchproject has it. The previous code filtered all workflow jobs
not having this property making the plugin GitHub Authorization Settings
not working for all workflow jobs.