### PR TITLE
[JENKINS-57154] Fix configureSecurity HTTP 403 err

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
@@ -32,13 +32,14 @@ import com.google.common.cache.CacheBuilder;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.OkUrlFactory;
 
+import hudson.model.Item;
 import hudson.security.Permission;
 import hudson.security.SecurityRealm;
-import hudson.model.Item;
 import jenkins.model.Jenkins;
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.GrantedAuthorityImpl;
 import org.acegisecurity.providers.AbstractAuthenticationToken;
+import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.kohsuke.github.GHMyself;
 import org.kohsuke.github.GHOrganization;
 import org.kohsuke.github.GHPersonSet;
@@ -198,7 +199,9 @@ public class GithubAuthenticationToken extends AbstractAuthenticationToken {
 
         this.me = loadMyself(accessToken);
 
-        assert this.me!=null;
+        if(this.me == null) {
+            throw new UsernameNotFoundException("Token not valid");
+        }
 
         setAuthenticated(true);
 

--- a/src/main/java/org/jenkinsci/plugins/GithubSecretStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecretStorage.java
@@ -24,11 +24,12 @@
 package org.jenkinsci.plugins;
 
 import hudson.model.User;
-import org.jfree.util.Log;
 
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import java.io.IOException;
 
 public class GithubSecretStorage {
 
@@ -43,20 +44,25 @@ public class GithubSecretStorage {
     public static @CheckForNull String retrieve(@Nonnull User user) {
         GithubAccessTokenProperty property = user.getProperty(GithubAccessTokenProperty.class);
         if (property == null) {
-            Log.debug("Cache miss for username: " + user.getId());
+            LOGGER.log(Level.FINE, "Cache miss for username: " + user.getId());
             return null;
         } else {
-            Log.debug("Token retrieved using cache for username: " + user.getId());
+            LOGGER.log(Level.FINE, "Token retrieved using cache for username: " + user.getId());
             return property.getAccessToken().getPlainText();
         }
     }
 
     public static void put(@Nonnull User user, @Nonnull String accessToken) {
-        Log.debug("Populating the cache for username: " + user.getId());
+        LOGGER.log(Level.FINE, "Populating the cache for username: " + user.getId());
         try {
             user.addProperty(new GithubAccessTokenProperty(accessToken));
         } catch (IOException e) {
-            Log.warn("Received an exception when trying to add the GitHub access token to the user: " + user.getId(), e);
+            LOGGER.log(Level.WARNING, "Received an exception when trying to add the GitHub access token to the user: " + user.getId(), e);
         }
     }
+
+    /**
+     * Logger for debugging purposes.
+     */
+    private static final Logger LOGGER = Logger.getLogger(GithubSecretStorage.class.getName());
 }


### PR DESCRIPTION
If an admin visits the `configureSecurity` page in Jenkins, then every user queried will attempt to be impersonated as part of determining if they're a user.  However, it's possible for some users to revoke the OAuth app or no longer have access so impersonation is not possible due to an invalid token.

The `GithubAuthenticationToken` class did not properly surface an error when a token authentication was not valid.

See also:

- [JENKINS-57154][JENKINS-57154] Regression in github-oauth-plugin 0.32 breaks /configureSecurity page

[JENKINS-57154]: https://issues.jenkins-ci.org/browse/JENKINS-57154