### PR TITLE
[JENKINS-34835] Reference GitHub teams by slug

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
@@ -541,7 +541,15 @@ public class GithubAuthenticationToken extends AbstractAuthenticationToken {
         try {
             GHOrganization org = loadOrganization(organization);
             if (org != null) {
-                return org.getTeamByName(team);
+
+                // JENKINS-34835 favor getting by slug but fall back to getting
+                // by name for compatibility since most Jenkins setups older
+                // than github-oauth 0.33 will be using team name
+                if(org.getTeamBySlug(team) != null) {
+                    return org.getTeamBySlug(team);
+                } else {
+                    return org.getTeamByName(team);
+                }
             }
         } catch (IOException e) {
             LOGGER.log(Level.FINEST, e.getMessage(), e);


### PR DESCRIPTION
This change references teams by slug but falls back to the old behavior of referencing by name for compatibility reasons.  This is so that when users upgrade they do not get authorization issues.

See also:

- [JENKINS-34835][JENKINS-34835] GitHub team should be referenced by slug not name

[JENKINS-34835]: https://issues.jenkins-ci.org/browse/JENKINS-34835