### PR TITLE
Prioritize Github Repo permissions

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
@@ -452,6 +452,7 @@ public class GithubRequireOrganizationMembershipACLTest extends TestCase {
     @Test
     public void testCanReadAProjectWithAuthenticatedUserReadPermission() throws IOException {
         this.authenticatedUserReadPermission = true;
+        this.useRepositoryPermissions = false;
 
         String nullProjectName = null;
         Project mockProject = mockProject(nullProjectName);


### PR DESCRIPTION
Previously members of authorised orgs were granted read access to
repos before the github permissions of the user were checked, even
if useRepositoryPermissions was enabled. This resulted in users
having read access to all jobs, even jobs for repos they don't have
access to.

This commit moves the github repo permissions check earlier so that
read can be denied to users if they don't have permissions on the repo.

Related: conjurinc/ops#658