### PR TITLE
Grant Replay permission along with build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
@@ -231,7 +231,8 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
     private boolean testBuildPermission(@Nonnull Permission permission) {
         String id = permission.getId();
         return id.equals("hudson.model.Hudson.Build")
-                || id.equals("hudson.model.Item.Build");
+                || id.equals("hudson.model.Item.Build")
+                || id.equals("hudson.model.Run.Replay");
     }
 
     private boolean checkReadPermission(@Nonnull Permission permission) {


### PR DESCRIPTION
Users who have the build permission, should also have the replay
permission, so they can restart jobs modifying the pipeline if
required.

Related: conjurinc/ops#680