### PR TITLE
[JEP-227] Prevent Stackoverflow during logout

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -570,7 +570,8 @@ public class GithubSecurityRealm extends AbstractPasswordBasedSecurityRealm impl
         Jenkins j = Jenkins.getInstance();
         assert j != null;
         if (j.hasPermission(Jenkins.READ)) {
-            return super.getPostLogOutUrl(req, auth);
+            // TODO until JEP-227 is merged and core requirement is updated, this will prevent stackoverflow
+            return req.getContextPath() + "/";
         }
         return req.getContextPath()+ "/" + GithubLogoutAction.POST_LOGOUT_URL;
     }


### PR DESCRIPTION
Due to the upcoming changes: https://github.com/jenkinsci/jenkins/pull/4848/files?file-filters%5B%5D=.java&hide-deleted-files=true#diff-7f1293bc6e17d8f944c084eaee7dad62R265-R279 there is an infinite loop when logging out.

Context information: https://github.com/jenkinsci/jep/tree/master/jep/227

@jglick 