### PR TITLE
[JENKINS-66302] Prepare GitHub Authentication for core Guava upgrade

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xmx256m -XX:MaxPermSize=128m -Djava.awt.headless=true
+-Xmx256m -Djava.awt.headless=true

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <properties>
-        <jenkins.version>2.176.4</jenkins.version>
+        <jenkins.version>2.222.1</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <profiles>
@@ -88,7 +88,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.176.x</artifactId>
+                <artifactId>bom-2.222.x</artifactId>
                 <version>11</version>
                 <scope>import</scope>
                 <type>pom</type>
@@ -97,6 +97,12 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>caffeine-api</artifactId>
+            <version>2.9.1-23.v51c4e2c879c8</version>
+        </dependency>
+
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mailer</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
@@ -26,14 +26,13 @@ THE SOFTWARE.
  */
 package org.jenkinsci.plugins;
 
-import com.google.common.collect.ImmutableList;
-
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.multibranch.BranchJobProperty;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import javax.annotation.Nonnull;
 
@@ -118,7 +117,7 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
     @Nonnull
     @Override
     public Collection<String> getGroups() {
-        return ImmutableList.of();
+        return Collections.emptyList();
     }
 
     private Object readResolve() {

--- a/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
@@ -26,8 +26,6 @@ THE SOFTWARE.
  */
 package org.jenkinsci.plugins;
 
-import com.google.common.collect.ImmutableMap;
-
 import junit.framework.TestCase;
 
 import org.acegisecurity.Authentication;


### PR DESCRIPTION
Downstream of #119, which should be merged before this PR (for this PR, please only review commit 390639b2599a0d83e60e4e9b94daf50ef0989e96). See [JENKINS-66302](https://issues.jenkins.io/browse/JENKINS-66302) and [JENKINS-65988](https://issues.jenkins.io/browse/JENKINS-65988). Jenkins core is using [Guava 11.0.1](https://github.com/google/guava/releases/tag/v11.0.1), which was released on January 9, 2012. Jenkins core would like to upgrade to [Guava 30.1.1](https://github.com/google/guava/releases/tag/v30.1.1), which was released on March 19, 2021. Plugins must be prepared to be compatible with both Guava 11.0.1 and Guava 30.1.1 in advance of this core transition.

In particular, this plugin has been identified as using the `com.google.common.cache.Cache#get` API, which has been removed between Guava [11.0.1](https://guava.dev/releases/11.0.1/api/docs/com/google/common/cache/Cache.html) and [latest](https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/cache/Cache.html). The removal took place in Guava 12.0.

To facilitate the Jenkins core transition, this plugin must be prepared and released such that it works with both Guava 11.0.1 and latest. The recommendation is for plugins to migrate from Guava's cache to [Caffeine](https://github.com/ben-manes/caffeine) via the Jenkins [Caffeine API](https://plugins.jenkins.io/caffeine-api/) plugin.

For the most part, the migration is a trivial matter of replacing imports of `com.google.common.cache.Cache` with imports of `com.github.benmanes.caffeine.cache.Cache` and imports of `com.google.common.cache.CacheBuilder` with imports of `com.github.benmanes.caffeine.cache.Caffeine`. I also replaced a usage of `ImmutableList.of` with a usage of `Collections.emptyList`. Finally I had to update the baseline to 2.222.x to be able to use the Caffeine API plugin.