### PR TITLE
Jenkins Plugin not able to retrieve infomation about user behind proxies requiring authentication

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
@@ -28,10 +28,6 @@ package org.jenkinsci.plugins;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import hudson.ProxyConfiguration;
-import okhttp3.Challenge;
-import okhttp3.Credentials;
-import okhttp3.OkHttpClient;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -39,7 +35,7 @@ import hudson.model.Item;
 import hudson.security.Permission;
 import hudson.security.SecurityRealm;
 import jenkins.model.Jenkins;
-import okhttp3.Request;
+import okhttp3.OkHttpClient;
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.GrantedAuthorityImpl;
 import org.acegisecurity.providers.AbstractAuthenticationToken;
@@ -52,6 +48,7 @@ import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
 import org.kohsuke.github.RateLimitHandler;
+import org.kohsuke.github.extras.okhttp3.OkHttpGitHubConnector;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -71,7 +68,6 @@ import java.util.logging.Logger;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import org.kohsuke.github.extras.okhttp3.OkHttpGitHubConnector;
 
 
 /**
@@ -293,17 +289,20 @@ public class GithubAuthenticationToken extends AbstractAuthenticationToken {
                 throw new IOException("Invalid GitHub API URL: " + this.githubServer, e);
             }
 
-            OkHttpClient client = new OkHttpClient.Builder()
-                    .proxy(getProxy(host))
-                    .proxyAuthenticator(new JenkinsProxyAuthenticator(Jenkins.get().getProxy()))
-                    .build();
+            OkHttpClient client =
+                    new OkHttpClient.Builder()
+                            .proxy(getProxy(host))
+                            .proxyAuthenticator(
+                                    new JenkinsProxyAuthenticator(Jenkins.get().getProxy()))
+                            .build();
 
-            this.gh = GitHubBuilder.fromEnvironment()
-                    .withEndpoint(this.githubServer)
-                    .withOAuthToken(this.accessToken)
-                    .withRateLimitHandler(RateLimitHandler.FAIL)
-                    .withConnector(new OkHttpGitHubConnector(client))
-                    .build();
+            this.gh =
+                    GitHubBuilder.fromEnvironment()
+                            .withEndpoint(this.githubServer)
+                            .withOAuthToken(this.accessToken)
+                            .withRateLimitHandler(RateLimitHandler.FAIL)
+                            .withConnector(new OkHttpGitHubConnector(client))
+                            .build();
         }
         return gh;
     }

--- a/src/main/java/org/jenkinsci/plugins/JenkinsProxyAuthenticator.java
+++ b/src/main/java/org/jenkinsci/plugins/JenkinsProxyAuthenticator.java
@@ -1,24 +1,23 @@
 package org.jenkinsci.plugins;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ProxyConfiguration;
 import hudson.util.Secret;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import okhttp3.Authenticator;
 import okhttp3.Challenge;
 import okhttp3.Credentials;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.Route;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class JenkinsProxyAuthenticator implements Authenticator {
 
 
-    private static final Logger LOGGER = Logger
-            .getLogger(JenkinsProxyAuthenticator.class.getName());
+    private static final Logger LOGGER =
+            Logger.getLogger(JenkinsProxyAuthenticator.class.getName());
 
     private final ProxyConfiguration proxy;
 
@@ -26,45 +25,49 @@ public class JenkinsProxyAuthenticator implements Authenticator {
         this.proxy = proxy;
     }
 
-    @Nullable
+    @CheckForNull
     @Override
-    public Request authenticate(@Nullable Route route, @NotNull Response response) {
+    public Request authenticate(@CheckForNull Route route, @NonNull Response response) {
 
-        if(response.request().header("Proxy-Authorization") != null) {
+        if (response.request().header("Proxy-Authorization") != null) {
             return null; // Give up since we already tried to authenticate
         }
 
-        if(response.challenges().isEmpty()) {
+        if (response.challenges().isEmpty()) {
             // Proxy does not require authentication
             return null;
         }
 
         // Refuse pre-emptive challenge
-        if(response.challenges().size() == 1) {
+        if (response.challenges().size() == 1) {
             Challenge challenge = response.challenges().get(0);
-            if(challenge.scheme().equalsIgnoreCase("OkHttp-Preemptive")) {
+            if (challenge.scheme().equalsIgnoreCase("OkHttp-Preemptive")) {
                 return null;
             }
         }
 
-        for(Challenge challenge : response.challenges()) {
-            if(challenge.scheme().equalsIgnoreCase("Basic")) {
+        for (Challenge challenge : response.challenges()) {
+            if (challenge.scheme().equalsIgnoreCase("Basic")) {
                 String username = proxy.getUserName();
                 Secret password = proxy.getSecretPassword();
-                if(username != null && password != null) {
+                if (username != null && password != null) {
                     String credentials = Credentials.basic(username, password.getPlainText());
                     return response.request()
                             .newBuilder()
                             .header("Proxy-Authorization", credentials)
                             .build();
                 } else {
-                    LOGGER.log(Level.WARNING, "Proxy requires Basic authentication but no username and password have been configured for the proxy");
+                    LOGGER.log(
+                            Level.WARNING,
+                            "Proxy requires Basic authentication but no username and password have been configured for the proxy");
                 }
                 break;
             }
         }
 
-        LOGGER.log(Level.WARNING, "Proxy requires authentication, but does not support Basic authentication");
+        LOGGER.log(
+                Level.WARNING,
+                "Proxy requires authentication, but does not support Basic authentication");
         return null;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/JenkinsProxyAuthenticator.java
+++ b/src/main/java/org/jenkinsci/plugins/JenkinsProxyAuthenticator.java
@@ -1,0 +1,70 @@
+package org.jenkinsci.plugins;
+
+import hudson.ProxyConfiguration;
+import hudson.util.Secret;
+import okhttp3.Authenticator;
+import okhttp3.Challenge;
+import okhttp3.Credentials;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.Route;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class JenkinsProxyAuthenticator implements Authenticator {
+
+
+    private static final Logger LOGGER = Logger
+            .getLogger(JenkinsProxyAuthenticator.class.getName());
+
+    private final ProxyConfiguration proxy;
+
+    public JenkinsProxyAuthenticator(ProxyConfiguration proxy) {
+        this.proxy = proxy;
+    }
+
+    @Nullable
+    @Override
+    public Request authenticate(@Nullable Route route, @NotNull Response response) {
+
+        if(response.request().header("Proxy-Authorization") != null) {
+            return null; // Give up since we already tried to authenticate
+        }
+
+        if(response.challenges().isEmpty()) {
+            // Proxy does not require authentication
+            return null;
+        }
+
+        // Refuse pre-emptive challenge
+        if(response.challenges().size() == 1) {
+            Challenge challenge = response.challenges().get(0);
+            if(challenge.scheme().equalsIgnoreCase("OkHttp-Preemptive")) {
+                return null;
+            }
+        }
+
+        for(Challenge challenge : response.challenges()) {
+            if(challenge.scheme().equalsIgnoreCase("Basic")) {
+                String username = proxy.getUserName();
+                Secret password = proxy.getSecretPassword();
+                if(username != null && password != null) {
+                    String credentials = Credentials.basic(username, password.getPlainText());
+                    return response.request()
+                            .newBuilder()
+                            .header("Authorization", credentials)
+                            .build();
+                } else {
+                    LOGGER.log(Level.WARNING, "Proxy requires Basic authentication but no username and password have been configured for the proxy");
+                }
+                break;
+            }
+        }
+
+        LOGGER.log(Level.WARNING, "Proxy requires authentication, but does not support Basic authentication");
+        return null;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/JenkinsProxyAuthenticator.java
+++ b/src/main/java/org/jenkinsci/plugins/JenkinsProxyAuthenticator.java
@@ -55,7 +55,7 @@ public class JenkinsProxyAuthenticator implements Authenticator {
                     String credentials = Credentials.basic(username, password.getPlainText());
                     return response.request()
                             .newBuilder()
-                            .header("Authorization", credentials)
+                            .header("Proxy-Authorization", credentials)
                             .build();
                 } else {
                     LOGGER.log(Level.WARNING, "Proxy requires Basic authentication but no username and password have been configured for the proxy");

--- a/src/test/java/org/jenkinsci/plugins/GithubAuthenticationTokenTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubAuthenticationTokenTest.java
@@ -10,6 +10,7 @@ import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
 import org.kohsuke.github.RateLimitHandler;
 import org.kohsuke.github.extras.OkHttpConnector;
+import org.kohsuke.github.extras.okhttp3.OkHttpGitHubConnector;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -71,7 +72,7 @@ public class GithubAuthenticationTokenTest {
         Mockito.when(builder.withEndpoint("https://api.github.com")).thenReturn(builder);
         Mockito.when(builder.withOAuthToken("accessToken")).thenReturn(builder);
         Mockito.when(builder.withRateLimitHandler(RateLimitHandler.FAIL)).thenReturn(builder);
-        Mockito.when(builder.withConnector(Mockito.any(OkHttpConnector.class))).thenReturn(builder);
+        Mockito.when(builder.withConnector(Mockito.any(OkHttpGitHubConnector.class))).thenReturn(builder);
         Mockito.when(builder.build()).thenReturn(gh);
         GHMyself me = Mockito.mock(GHMyself.class);
         Mockito.when(gh.getMyself()).thenReturn(me);

--- a/src/test/java/org/jenkinsci/plugins/GithubAuthenticationTokenTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubAuthenticationTokenTest.java
@@ -9,7 +9,6 @@ import org.kohsuke.github.GHMyself;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
 import org.kohsuke.github.RateLimitHandler;
-import org.kohsuke.github.extras.OkHttpConnector;
 import org.kohsuke.github.extras.okhttp3.OkHttpGitHubConnector;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;

--- a/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
@@ -47,7 +47,6 @@ import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
 import org.kohsuke.github.PagedIterable;
 import org.kohsuke.github.RateLimitHandler;
-import org.kohsuke.github.extras.OkHttpConnector;
 import org.kohsuke.github.extras.okhttp3.OkHttpGitHubConnector;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;

--- a/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
@@ -48,6 +48,7 @@ import org.kohsuke.github.GitHubBuilder;
 import org.kohsuke.github.PagedIterable;
 import org.kohsuke.github.RateLimitHandler;
 import org.kohsuke.github.extras.OkHttpConnector;
+import org.kohsuke.github.extras.okhttp3.OkHttpGitHubConnector;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.mockito.Mock;
@@ -161,7 +162,7 @@ public class GithubRequireOrganizationMembershipACLTest {
         Mockito.when(builder.withEndpoint("https://api.github.com")).thenReturn(builder);
         Mockito.when(builder.withOAuthToken("accessToken")).thenReturn(builder);
         Mockito.when(builder.withRateLimitHandler(RateLimitHandler.FAIL)).thenReturn(builder);
-        Mockito.when(builder.withConnector(Mockito.any(OkHttpConnector.class))).thenReturn(builder);
+        Mockito.when(builder.withConnector(Mockito.any(OkHttpGitHubConnector.class))).thenReturn(builder);
         Mockito.when(builder.build()).thenReturn(gh);
         GHMyself me = Mockito.mock(GHMyself.class);
         Mockito.when(gh.getMyself()).thenReturn(me);

--- a/src/test/java/org/jenkinsci/plugins/JenkinsProxyAuthenticatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/JenkinsProxyAuthenticatorTest.java
@@ -14,73 +14,73 @@ public class JenkinsProxyAuthenticatorTest {
 
     @Test
     public void refusesChallengeIfAuthenticationAlreadyFailed() {
-        Request previousRequest = new Request.Builder()
-                .url("https://example.com")
-                .header("Proxy-Authorization", "notNull")
-                .build();
+        Request previousRequest =
+                new Request.Builder()
+                        .url("https://example.com")
+                        .header("Proxy-Authorization", "notNull")
+                        .build();
 
-        Response response = new Response.Builder()
-                .code(407)
-                .request(previousRequest)
-                .protocol(Protocol.HTTP_1_0)
-                .message("Unauthorized")
-                .build();
+        Response response =
+                new Response.Builder()
+                        .code(407)
+                        .request(previousRequest)
+                        .protocol(Protocol.HTTP_1_0)
+                        .message("Unauthorized")
+                        .build();
 
         Assert.assertNull(new JenkinsProxyAuthenticator(null).authenticate(null, response));
     }
 
     @Test
     public void refusesPreemptiveOkHttpChallenge() {
-        Request previousRequest = new Request.Builder()
-                .url("https://example.com")
-                .build();
+        Request previousRequest = new Request.Builder().url("https://example.com").build();
 
-        Response response = new Response.Builder()
-                .request(previousRequest)
-                .header("Proxy-Authenticate", "OkHttp-Preemptive")
-                .code(407)
-                .protocol(Protocol.HTTP_1_0)
-                .message("Unauthorized")
-                .build();
+        Response response =
+                new Response.Builder()
+                        .request(previousRequest)
+                        .header("Proxy-Authenticate", "OkHttp-Preemptive")
+                        .code(407)
+                        .protocol(Protocol.HTTP_1_0)
+                        .message("Unauthorized")
+                        .build();
 
         Assert.assertNull(new JenkinsProxyAuthenticator(null).authenticate(null, response));
     }
 
     @Test
     public void acceptsBasicChallenge() {
-        Request previousRequest = new Request.Builder()
-                .url("https://example.com")
-                .build();
+        Request previousRequest = new Request.Builder().url("https://example.com").build();
 
-        Response response = new Response.Builder()
-                .request(previousRequest)
-                .header("Proxy-Authenticate", "Basic")
-                .code(407)
-                .protocol(Protocol.HTTP_1_0)
-                .message("Unauthorized")
-                .build();
+        Response response =
+                new Response.Builder()
+                        .request(previousRequest)
+                        .header("Proxy-Authenticate", "Basic")
+                        .code(407)
+                        .protocol(Protocol.HTTP_1_0)
+                        .message("Unauthorized")
+                        .build();
 
-        ProxyConfiguration proxyConfiguration = new ProxyConfiguration("proxy", 80, "user", "password");
+        ProxyConfiguration proxyConfiguration =
+                new ProxyConfiguration("proxy", 80, "user", "password");
         String credentials = Credentials.basic("user", "password");
-        Request requestWithBasicAuth = new JenkinsProxyAuthenticator(proxyConfiguration).authenticate(null, response);
+        Request requestWithBasicAuth =
+                new JenkinsProxyAuthenticator(proxyConfiguration).authenticate(null, response);
 
         Assert.assertEquals(requestWithBasicAuth.header("Proxy-Authorization"), credentials);
     }
 
     @Test
     public void refusesAnyChallengeWhichIsNotBasicAuthentication() {
-        Request previousRequest = new Request.Builder()
-                .url("https://example.com")
-                .build();
+        Request previousRequest = new Request.Builder().url("https://example.com").build();
 
-        Response response = new Response.Builder()
-                .request(previousRequest)
-                .code(407)
-                .protocol(Protocol.HTTP_1_0)
-                .header("Proxy-Authenticate", "Digest")
-                .message("Unauthorized")
-                .build();
-
+        Response response =
+                new Response.Builder()
+                        .request(previousRequest)
+                        .code(407)
+                        .protocol(Protocol.HTTP_1_0)
+                        .header("Proxy-Authenticate", "Digest")
+                        .message("Unauthorized")
+                        .build();
 
         Assert.assertNull(new JenkinsProxyAuthenticator(null).authenticate(null, response));
     }

--- a/src/test/java/org/jenkinsci/plugins/JenkinsProxyAuthenticatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/JenkinsProxyAuthenticatorTest.java
@@ -64,7 +64,7 @@ public class JenkinsProxyAuthenticatorTest {
         String credentials = Credentials.basic("user", "password");
         Request requestWithBasicAuth = new JenkinsProxyAuthenticator(proxyConfiguration).authenticate(null, response);
 
-        Assert.assertEquals(requestWithBasicAuth.header("Authorization"), credentials);
+        Assert.assertEquals(requestWithBasicAuth.header("Proxy-Authorization"), credentials);
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/JenkinsProxyAuthenticatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/JenkinsProxyAuthenticatorTest.java
@@ -1,0 +1,88 @@
+package org.jenkinsci.plugins;
+
+import hudson.ProxyConfiguration;
+import okhttp3.Credentials;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class JenkinsProxyAuthenticatorTest {
+
+
+    @Test
+    public void refusesChallengeIfAuthenticationAlreadyFailed() {
+        Request previousRequest = new Request.Builder()
+                .url("https://example.com")
+                .header("Proxy-Authorization", "notNull")
+                .build();
+
+        Response response = new Response.Builder()
+                .code(407)
+                .request(previousRequest)
+                .protocol(Protocol.HTTP_1_0)
+                .message("Unauthorized")
+                .build();
+
+        Assert.assertNull(new JenkinsProxyAuthenticator(null).authenticate(null, response));
+    }
+
+    @Test
+    public void refusesPreemptiveOkHttpChallenge() {
+        Request previousRequest = new Request.Builder()
+                .url("https://example.com")
+                .build();
+
+        Response response = new Response.Builder()
+                .request(previousRequest)
+                .header("Proxy-Authenticate", "OkHttp-Preemptive")
+                .code(407)
+                .protocol(Protocol.HTTP_1_0)
+                .message("Unauthorized")
+                .build();
+
+        Assert.assertNull(new JenkinsProxyAuthenticator(null).authenticate(null, response));
+    }
+
+    @Test
+    public void acceptsBasicChallenge() {
+        Request previousRequest = new Request.Builder()
+                .url("https://example.com")
+                .build();
+
+        Response response = new Response.Builder()
+                .request(previousRequest)
+                .header("Proxy-Authenticate", "Basic")
+                .code(407)
+                .protocol(Protocol.HTTP_1_0)
+                .message("Unauthorized")
+                .build();
+
+        ProxyConfiguration proxyConfiguration = new ProxyConfiguration("proxy", 80, "user", "password");
+        String credentials = Credentials.basic("user", "password");
+        Request requestWithBasicAuth = new JenkinsProxyAuthenticator(proxyConfiguration).authenticate(null, response);
+
+        Assert.assertEquals(requestWithBasicAuth.header("Authorization"), credentials);
+    }
+
+    @Test
+    public void refusesAnyChallengeWhichIsNotBasicAuthentication() {
+        Request previousRequest = new Request.Builder()
+                .url("https://example.com")
+                .build();
+
+        Response response = new Response.Builder()
+                .request(previousRequest)
+                .code(407)
+                .protocol(Protocol.HTTP_1_0)
+                .header("Proxy-Authenticate", "Digest")
+                .message("Unauthorized")
+                .build();
+
+
+        Assert.assertNull(new JenkinsProxyAuthenticator(null).authenticate(null, response));
+    }
+
+}


### PR DESCRIPTION
Fix the usage of github authentication plugin behind proxies requiring authentication

If we configure the Jenkins server to be used behind a proxy which requires
authentication, then Jenkins authentication plugin becomes unusable. The
reason for that is the fact that configured username and password are not
passed into the httpclient from Jenkins configuration.

To reproduce this error do following:

- Start Jenkins server behind proxy requiring authentication
- Configure the gihub authentication plugin
- Clear your browser cookies
- Try to login
- Observe the login looping due to missing access token

This PR fixes the issue.