### PR TITLE
[JENKINS-60200] Clear user team and organization caches on fresh OAuth logins

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -400,7 +400,7 @@ public class GithubSecurityRealm extends AbstractPasswordBasedSecurityRealm impl
 
         if (accessToken != null && accessToken.trim().length() > 0) {
             // only set the access token if it exists.
-            GithubAuthenticationToken auth = new GithubAuthenticationToken(accessToken, getGithubApiUri());
+            GithubAuthenticationToken auth = new GithubAuthenticationToken(accessToken, getGithubApiUri(), true);
 
             HttpSession session = request.getSession(false);
             if(session != null){

--- a/src/test/java/org/jenkinsci/plugins/GithubAccessTokenPropertyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubAccessTokenPropertyTest.java
@@ -347,10 +347,42 @@ public class GithubAccessTokenPropertyTest {
         makeRequestWithAuthCodeAndVerify(encodeBasic(bobLogin, bobApiRestToken), "bob", Arrays.asList("authenticated", "org-c", "org-c*team-d"));
 
         GithubAuthenticationToken.clearCaches();
-        wc = j.createWebClient();
+
         // retrieve the security group even without the cookie (using LastGrantedAuthorities this time)
         makeRequestWithAuthCodeAndVerify(encodeBasic(bobLogin, bobApiRestToken), "bob", Arrays.asList("authenticated", "org-c", "org-c*team-d"));
     }
+
+    @Issue("JENKINS-60200")
+    @Test
+    public void testInvalidateAuthorizationCacheOnFreshLogin() throws IOException {
+        String bobLogin = "bob";
+        servlet.currentLogin = bobLogin;
+        servlet.organizations = Collections.singletonList("org-c");
+        Map<String, String> team = new HashMap<>();
+        team.put("slug", "team-d");
+        team.put("name", "Team D");
+        servlet.teams = Collections.singletonList(team);
+
+        User bobUser = User.getById(bobLogin, true);
+        String bobApiRestToken = bobUser.getProperty(ApiTokenProperty.class).getApiToken();
+
+        // request whoAmI with ApiRestToken => group populated
+        makeRequestWithAuthCodeAndVerify(encodeBasic(bobLogin, bobApiRestToken), "bob", Arrays.asList("authenticated", "org-c", "org-c*team-d"));
+        // request whoAmI with GitHub OAuth => group populated
+        makeRequestUsingOAuth("bob", Arrays.asList("authenticated", "org-c", "org-c*team-d"));
+
+        // Switch the teams
+        team.put("slug", "team-e");
+        team.put("name", "Team E");
+        servlet.teams = Collections.singletonList(team);
+
+        // With just AuthCode, the cache is not invalidated
+        makeRequestWithAuthCodeAndVerify(encodeBasic(bobLogin, bobApiRestToken), "bob", Arrays.asList("authenticated", "org-c", "org-c*team-d"));
+
+        // With OAuth the cache is invalidated
+        makeRequestUsingOAuth("bob", Arrays.asList("authenticated", "org-c", "org-c*team-e"));
+    }
+
 
     private void makeRequestWithAuthCodeAndVerify(String authCode, String expectedLogin, List<String> expectedAuthorities) throws IOException {
         WebRequest req = new WebRequest(new URL(j.getURL(), "whoAmI/api/json"));


### PR DESCRIPTION
Per: https://issues.jenkins.io/browse/JENKINS-60200

Sometimes the 1-hour cache of teams and organizations can cause issues. In particular, it causes problems when you have SSO turned on for an organization and the person logging in needs to remember to authorize SSO for a given organization and forgets. 

The user story is this:
I log into a Jenkins with team-level permissions in my SSO enabled organization. I see this screen:
![image](https://user-images.githubusercontent.com/596029/161162755-1dab5fd7-a34c-410d-bdd7-409fa302255c.png)

and I forget to click the `Authorize` button. I then get permission denied. I then click logout to try and fix that, but when I come back in after authorizing my organization; I still get permission denied because of the cache.

This PR invalidate the cache on fresh logins. This both solves the reported issue, and allows a user to have an active way to refresh their personal cache of teams and organizations by logging out and logging in while leaving caching in place for token flows and session accesses for performance and to minimize GitHub API calls.

Notes: I didn't see a logout hook in the Security Realm or I'd prefer to clear the caches there instead of during the fresh OAuth flow. If someone with more expertise knows how to hook there, I'm happy to move the user cache clearing to that hook.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
