### PR TITLE
Add Jenkins agent support for GitHub Committer Authorization Strategy

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
@@ -142,6 +142,10 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
         return StringUtils.join(rootACL.getAdminUserNameList().iterator(), ", ");
     }
 
+    /**
+     * @return agentUserName
+     * @see GithubRequireOrganizationMembershipACL#getAgentUserName()
+     */
     public String getAgentUserName() {
         return rootACL.getAgentUserName();
     }

--- a/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.multibranch.BranchJobProperty;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -55,7 +56,6 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
 
     @DataBoundConstructor
     public GithubAuthorizationStrategy(String adminUserNames,
-            String agentUserName,
             boolean authenticatedUserReadPermission,
             boolean useRepositoryPermissions,
             boolean authenticatedUserCreateJobPermission,
@@ -67,7 +67,6 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
         super();
 
         rootACL = new GithubRequireOrganizationMembershipACL(adminUserNames,
-                agentUserName,
                 organizationNames,
                 authenticatedUserReadPermission,
                 useRepositoryPermissions,
@@ -140,6 +139,15 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
      */
     public String getAdminUserNames() {
         return StringUtils.join(rootACL.getAdminUserNameList().iterator(), ", ");
+    }
+
+    /** Set the agent username. We use a setter instead of a constructor to make this an optional field
+     *  to avoid a breaking change.
+     * @see org.jenkinsci.plugins.GithubRequireOrganizationMembershipACL#setAgentUserName(String)
+     */
+    @DataBoundSetter
+    public void setAgentUserName(String agentUserName) {
+        rootACL.setAgentUserName(agentUserName);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
@@ -55,6 +55,7 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
 
     @DataBoundConstructor
     public GithubAuthorizationStrategy(String adminUserNames,
+            String agentUserName,
             boolean authenticatedUserReadPermission,
             boolean useRepositoryPermissions,
             boolean authenticatedUserCreateJobPermission,
@@ -66,6 +67,7 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
         super();
 
         rootACL = new GithubRequireOrganizationMembershipACL(adminUserNames,
+                agentUserName,
                 organizationNames,
                 authenticatedUserReadPermission,
                 useRepositoryPermissions,
@@ -140,6 +142,10 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
         return StringUtils.join(rootACL.getAdminUserNameList().iterator(), ", ");
     }
 
+    public String getAgentUserName() {
+        return rootACL.getAgentUserName();
+    }
+
     /**
      * @return isUseRepositoryPermissions
      * @see org.jenkinsci.plugins.GithubRequireOrganizationMembershipACL#isUseRepositoryPermissions()
@@ -208,6 +214,7 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
             GithubAuthorizationStrategy obj = (GithubAuthorizationStrategy) object;
             return this.getOrganizationNames().equals(obj.getOrganizationNames()) &&
                 this.getAdminUserNames().equals(obj.getAdminUserNames()) &&
+                this.getAgentUserName().equals(obj.getAgentUserName()) &&
                 this.isUseRepositoryPermissions() == obj.isUseRepositoryPermissions() &&
                 this.isAuthenticatedUserCreateJobPermission() == obj.isAuthenticatedUserCreateJobPermission() &&
                 this.isAuthenticatedUserReadPermission() == obj.isAuthenticatedUserReadPermission() &&

--- a/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
@@ -250,11 +250,10 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
     }
 
     private boolean checkAgentUserPermission(@NonNull Permission permission) {
-        String id = permission.getId();
-        return (id.equals(Hudson.READ)
-                || id.equals(Computer.CREATE)
-                || id.equals(Computer.CONNECT)
-                || id.equals(Computer.CONFIGURE));
+        return permission.equals(Hudson.READ)
+                || permission.equals(Computer.CREATE)
+                || permission.equals(Computer.CONNECT)
+                || permission.equals(Computer.CONFIGURE);
     }
 
     private boolean checkJobStatusPermission(@NonNull Permission permission) {

--- a/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
@@ -64,7 +64,7 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 
     private final List<String> organizationNameList;
     private final List<String> adminUserNameList;
-    private final String agentUserName;
+    private String agentUserName;
     private final boolean authenticatedUserReadPermission;
     private final boolean useRepositoryPermissions;
     private final boolean authenticatedUserCreateJobPermission;
@@ -299,7 +299,6 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
     }
 
     public GithubRequireOrganizationMembershipACL(String adminUserNames,
-            String agentUserName,
             String organizationNames,
             boolean authenticatedUserReadPermission,
             boolean useRepositoryPermissions,
@@ -318,7 +317,6 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
         this.allowAnonymousReadPermission         = allowAnonymousReadPermission;
         this.allowAnonymousJobStatusPermission    = allowAnonymousJobStatusPermission;
         this.adminUserNameList                    = new LinkedList<>();
-        this.agentUserName                        = agentUserName;
 
         String[] parts = adminUserNames.split(",");
 
@@ -335,12 +333,12 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
         }
 
         this.item = null;
+        this.agentUserName = ""; // Initially blank - populated by a setter since this field is optional
     }
 
     public GithubRequireOrganizationMembershipACL cloneForProject(AbstractItem item) {
-      return new GithubRequireOrganizationMembershipACL(
+        GithubRequireOrganizationMembershipACL acl = new GithubRequireOrganizationMembershipACL(
           this.adminUserNameList,
-          this.agentUserName,
           this.organizationNameList,
           this.authenticatedUserReadPermission,
           this.useRepositoryPermissions,
@@ -350,10 +348,11 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
           this.allowAnonymousReadPermission,
           this.allowAnonymousJobStatusPermission,
           item);
+        acl.setAgentUserName(agentUserName);
+        return acl;
     }
 
     public GithubRequireOrganizationMembershipACL(List<String> adminUserNameList,
-            String agentUserName,
             List<String> organizationNameList,
             boolean authenticatedUserReadPermission,
             boolean useRepositoryPermissions,
@@ -366,7 +365,6 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
         super();
 
         this.adminUserNameList                    = adminUserNameList;
-        this.agentUserName                   = agentUserName;
         this.organizationNameList                 = organizationNameList;
         this.authenticatedUserReadPermission      = authenticatedUserReadPermission;
         this.useRepositoryPermissions             = useRepositoryPermissions;
@@ -386,6 +384,9 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
         return adminUserNameList;
     }
 
+    public void setAgentUserName(String agentUserName) {
+        this.agentUserName = agentUserName;
+    }
     public String getAgentUserName() { return agentUserName; }
 
     public boolean isUseRepositoryPermissions() {

--- a/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
@@ -105,6 +105,7 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 
             // Grant agent permissions to agent user
             if (candidateName.equalsIgnoreCase(agentUserName) && checkAgentUserPermission(permission)) {
+                log.finest("Granting Agent Connect rights to user " + candidateName);
                 return true;
             }
 
@@ -161,6 +162,7 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 
             // Grant agent permissions to agent user
             if (authenticatedUserName.equalsIgnoreCase(agentUserName) && checkAgentUserPermission(permission)) {
+                log.finest("Granting Agent Connect rights to user " + authenticatedUserName);
                 return true;
             }
 

--- a/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
@@ -26,6 +26,7 @@ THE SOFTWARE.
  */
 package org.jenkinsci.plugins;
 
+import hudson.model.*;
 import org.acegisecurity.Authentication;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -41,10 +42,6 @@ import java.util.logging.Logger;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
-import hudson.model.AbstractItem;
-import hudson.model.AbstractProject;
-import hudson.model.Describable;
-import hudson.model.Item;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.UserRemoteConfig;
 import hudson.security.ACL;
@@ -254,10 +251,10 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 
     private boolean checkAgentUserPermission(@NonNull Permission permission) {
         String id = permission.getId();
-        return (id.equals("hudson.model.Hudson.Read")
-                || id.equals("hudson.model.Computer.Create")
-                || id.equals("hudson.model.Computer.Connect")
-                || id.equals("hudson.model.Computer.Configure"));
+        return (id.equals(Hudson.READ)
+                || id.equals(Computer.CREATE)
+                || id.equals(Computer.CONNECT)
+                || id.equals(Computer.CONFIGURE));
     }
 
     private boolean checkJobStatusPermission(@NonNull Permission permission) {

--- a/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
@@ -252,7 +252,7 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 
     private boolean checkAgentUserPermission(@NonNull Permission permission) {
         String id = permission.getId();
-        return (checkReadPermission(permission)
+        return (id.equals("hudson.model.Hudson.Read")
                 || id.equals("hudson.model.Computer.Create")
                 || id.equals("hudson.model.Computer.Connect")
                 || id.equals("hudson.model.Computer.Configure"));

--- a/src/main/resources/org/jenkinsci/plugins/GithubAuthorizationStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/GithubAuthorizationStrategy/config.jelly
@@ -8,6 +8,10 @@
             <f:textbox />
         </f:entry>
 
+        <f:entry title="Agent User Name"  field="agentUserName" help="/plugin/github-oauth/help/auth/agent-user-name-help.html" >
+            <f:textbox />
+        </f:entry>
+
         <f:entry title="Participant in Organization"  field="organizationNames" help="/plugin/github-oauth/help/auth/organization-names-help.html">
             <f:textbox />
         </f:entry>

--- a/src/main/webapp/help/auth/agent-user-name-help.html
+++ b/src/main/webapp/help/auth/agent-user-name-help.html
@@ -1,0 +1,3 @@
+<div>
+If you are using a cluster of Jenkins agents (e.g. using the swarm plugin) this is the user that is used for authenticating agents. This user will receive the overall read rights as well as rights to create, connect and configure agents.
+</div>

--- a/src/main/webapp/help/auth/agent-user-name-help.html
+++ b/src/main/webapp/help/auth/agent-user-name-help.html
@@ -1,3 +1,3 @@
 <div>
-If you are using a cluster of Jenkins agents (e.g. using the swarm plugin) this is the user that is used for authenticating agents. This user will receive the overall read rights as well as rights to create, connect and configure agents.
+If you are using inbound Jenkins agents, this is the user that is used for authenticating agents. This user will receive rights to create, connect and configure agents.
 </div>

--- a/src/test/java/org/jenkinsci/plugins/GithubAuthorizationStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubAuthorizationStrategyTest.java
@@ -32,14 +32,14 @@ import org.junit.Test;
 public class GithubAuthorizationStrategyTest {
     @Test
     public void testEquals_true() {
-        GithubAuthorizationStrategy a = new GithubAuthorizationStrategy("",  "", false, true, false, "", false, false, false, false);
-        GithubAuthorizationStrategy b = new GithubAuthorizationStrategy("", "", false, true, false, "", false, false, false, false);
+        GithubAuthorizationStrategy a = new GithubAuthorizationStrategy("", false, true, false, "", false, false, false, false);
+        GithubAuthorizationStrategy b = new GithubAuthorizationStrategy("", false, true, false, "", false, false, false, false);
         assertEquals(a, b);
     }
     @Test
     public void testEquals_false() {
-        GithubAuthorizationStrategy a = new GithubAuthorizationStrategy("", "", false, true, false, "", false, false, false, false);
-        GithubAuthorizationStrategy b = new GithubAuthorizationStrategy("", "", false, false, false, "", false, false, false, false);
+        GithubAuthorizationStrategy a = new GithubAuthorizationStrategy("", false, true, false, "", false, false, false, false);
+        GithubAuthorizationStrategy b = new GithubAuthorizationStrategy("", false, false, false, "", false, false, false, false);
         assertNotEquals(a, b);
         assertNotEquals("", a);
     }

--- a/src/test/java/org/jenkinsci/plugins/GithubAuthorizationStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubAuthorizationStrategyTest.java
@@ -32,14 +32,14 @@ import org.junit.Test;
 public class GithubAuthorizationStrategyTest {
     @Test
     public void testEquals_true() {
-        GithubAuthorizationStrategy a = new GithubAuthorizationStrategy("", false, true, false, "", false, false, false, false);
-        GithubAuthorizationStrategy b = new GithubAuthorizationStrategy("", false, true, false, "", false, false, false, false);
+        GithubAuthorizationStrategy a = new GithubAuthorizationStrategy("",  "", false, true, false, "", false, false, false, false);
+        GithubAuthorizationStrategy b = new GithubAuthorizationStrategy("", "", false, true, false, "", false, false, false, false);
         assertEquals(a, b);
     }
     @Test
     public void testEquals_false() {
-        GithubAuthorizationStrategy a = new GithubAuthorizationStrategy("", false, true, false, "", false, false, false, false);
-        GithubAuthorizationStrategy b = new GithubAuthorizationStrategy("", false, false, false, "", false, false, false, false);
+        GithubAuthorizationStrategy a = new GithubAuthorizationStrategy("", "", false, true, false, "", false, false, false, false);
+        GithubAuthorizationStrategy b = new GithubAuthorizationStrategy("", "", false, false, false, "", false, false, false, false);
         assertNotEquals(a, b);
         assertNotEquals("", a);
     }

--- a/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
@@ -132,6 +132,7 @@ public class GithubRequireOrganizationMembershipACLTest {
     private GithubRequireOrganizationMembershipACL createACL() {
         return new GithubRequireOrganizationMembershipACL(
                 "admin",
+                "agent",
                 "myOrg",
                 authenticatedUserReadPermission,
                 useRepositoryPermissions,

--- a/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
@@ -131,9 +131,8 @@ public class GithubRequireOrganizationMembershipACLTest {
             new GrantedAuthority[]{new GrantedAuthorityImpl("anonymous")});
 
     private GithubRequireOrganizationMembershipACL createACL() {
-        return new GithubRequireOrganizationMembershipACL(
+        GithubRequireOrganizationMembershipACL acl = new GithubRequireOrganizationMembershipACL(
                 "admin",
-                "agent",
                 "myOrg",
                 authenticatedUserReadPermission,
                 useRepositoryPermissions,
@@ -142,6 +141,8 @@ public class GithubRequireOrganizationMembershipACLTest {
                 allowAnonymousCCTrayPermission,
                 allowAnonymousReadPermission,
                 allowAnonymousJobStatusPermission);
+        acl.setAgentUserName("agent");
+        return acl;
     }
 
     private GithubRequireOrganizationMembershipACL aclForProject(Project project) {

--- a/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
@@ -60,6 +60,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import hudson.model.Computer;
 import hudson.model.Hudson;
 import hudson.model.Item;
 import hudson.model.Messages;
@@ -553,6 +554,30 @@ public class GithubRequireOrganizationMembershipACLTest {
 
             assertFalse(acl.hasPermission(authenticationToken, Item.READ));
         }
+    }
+
+    @Test
+    public void testAgentUserCanCreateConnectAndConfigureAgents() {
+        GithubAuthenticationToken authenticationToken = Mockito.mock(GithubAuthenticationToken.class);
+        Mockito.when(authenticationToken.isAuthenticated()).thenReturn(true);
+        Mockito.when(authenticationToken.getName()).thenReturn("agent");
+        GithubRequireOrganizationMembershipACL acl = createACL();
+
+        assertTrue(acl.hasPermission(authenticationToken, Computer.CREATE));
+        assertTrue(acl.hasPermission(authenticationToken, Computer.CONFIGURE));
+        assertTrue(acl.hasPermission(authenticationToken, Computer.CONNECT));
+    }
+
+    @Test
+    public void testAuthenticatedCanNotCreateConnectAndConfigureAgents() {
+        GithubAuthenticationToken authenticationToken = Mockito.mock(GithubAuthenticationToken.class);
+        Mockito.when(authenticationToken.isAuthenticated()).thenReturn(true);
+        Mockito.when(authenticationToken.getName()).thenReturn("authenticated");
+        GithubRequireOrganizationMembershipACL acl = createACL();
+
+        assertFalse(acl.hasPermission(authenticationToken, Computer.CREATE));
+        assertFalse(acl.hasPermission(authenticationToken, Computer.CONFIGURE));
+        assertFalse(acl.hasPermission(authenticationToken, Computer.CONNECT));
     }
 
     @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
### Problem
A common use case for bigger Jenkins setups is to use a plugin like the [Swarm plugin](https://plugins.jenkins.io/swarm/) to form an ad-hoc cluster. This plugin allows that agents that can be added and removed flexibly to and from the Jenkins server. Those agents require authentication and authorization to create, configure and add new computers to the Jenkins. Using the github-oauth-plugin the authentication for the agent is already possible using an GitHub access token with minimal rights from a GitHub user.

However, the authorization is not working if the **GitHub Committer Authorization Strategy** is selected as the access rights retrieved from GitHub are not sufficient in this use case and there is no way to add additional custom rights to users.

### Solution
To solve this problem this PR adds a new field in the GitHub Committer Authorization Strategy configuration window that allows the specification of an optional **Agent User Name**. The user specified in that field will be provided with the following rights that are necessary for the agent user:

- Overall Read Permission
- Create Computers
- Configure Computers
- Connect Computers

The PR also adds a help dialog for this field and it includes unit tests to test that the right permissions are assigned to (and only to) the specified agent user.

### Checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
