### PR TITLE
Upgrade plugin parent POM to 4.60

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.57</version>
+        <version>4.60</version>
         <relativePath />
     </parent>
 
@@ -121,7 +121,7 @@
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Adapts to https://github.com/mockito/mockito/pull/2945 by switching our dependency from `mockito-inline` to `mockito-core`.