### PR TITLE
[JENKINS-63421] Add agentServiceAccounts optional config

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
@@ -30,9 +30,11 @@ import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.multibranch.BranchJobProperty;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedList;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -140,6 +142,28 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
         return StringUtils.join(rootACL.getAdminUserNameList().iterator(), ", ");
     }
 
+    /** Set the agent service accounts. We use a setter instead of a constructor to make this an optional
+     *  to avoid a breaking change.
+     * @see org.jenkinsci.plugins.GithubRequireOrganizationMembershipACL#setAgentServiceAccountList(List)
+     */
+    @DataBoundSetter
+    public void setAgentServiceAccounts(String accounts) {
+        LinkedList<String> list = new LinkedList<String>();
+        for (String account : accounts.split(",")) {
+            list.add(account.trim());
+        }
+        rootACL.setAgentServiceAccountList(list);
+    }
+
+    /**
+     * @return agentServiceAccounts
+     * @see org.jenkinsci.plugins.GithubRequireOrganizationMembershipACL#getAgentServiceAccountList()
+     */
+    public String getAgentServiceAccounts() {
+        return StringUtils.join(rootACL.getAgentServiceAccountList().iterator(), ", ");
+    }
+
+
     /**
      * @return isUseRepositoryPermissions
      * @see org.jenkinsci.plugins.GithubRequireOrganizationMembershipACL#isUseRepositoryPermissions()
@@ -208,6 +232,7 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
             GithubAuthorizationStrategy obj = (GithubAuthorizationStrategy) object;
             return this.getOrganizationNames().equals(obj.getOrganizationNames()) &&
                 this.getAdminUserNames().equals(obj.getAdminUserNames()) &&
+                this.getAgentServiceAccounts().equals(obj.getAgentServiceAccounts()) &&
                 this.isUseRepositoryPermissions() == obj.isUseRepositoryPermissions() &&
                 this.isAuthenticatedUserCreateJobPermission() == obj.isAuthenticatedUserCreateJobPermission() &&
                 this.isAuthenticatedUserReadPermission() == obj.isAuthenticatedUserReadPermission() &&

--- a/src/main/resources/org/jenkinsci/plugins/GithubAuthorizationStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/GithubAuthorizationStrategy/config.jelly
@@ -8,6 +8,10 @@
             <f:textbox />
         </f:entry>
 
+        <f:entry title="Agent Service Accounts"  field="agentServiceAccounts" help="/plugin/github-oauth/help/auth/agent-service-accounts-help.html" >
+            <f:textbox />
+        </f:entry>
+
         <f:entry title="Participant in Organization"  field="organizationNames" help="/plugin/github-oauth/help/auth/organization-names-help.html">
             <f:textbox />
         </f:entry>

--- a/src/main/webapp/help/auth/agent-service-accounts-help.html
+++ b/src/main/webapp/help/auth/agent-service-accounts-help.html
@@ -1,0 +1,3 @@
+<div>
+Comma-separated list of user names that when authenticated should be given agent connection rights. This applies the principle of least privilege to Jenkins agents, in case their credential is compromised.
+</div>


### PR DESCRIPTION
This is intended to address: [JENKINS-63421](https://issues.jenkins.io/browse/JENKINS-63421).

This plugin assigns Jenkins permissions based on their GitHub permissions - if a user can read a repo then they can view and execute the job.

However there exists no role that to represent the service account used by Jenkins agents to connect to the controller. This means that plugin users are forced to make the service account an admin, and this presents a security risk because the service account credentials exist on every agent if you know where to look.

An attacker can take the credentials from the agent and use them to become a Jenkins admin.

Our fork introduces a configurable `agentServiceAccounts` field which has the proper, reduced permissions.

<img width="1255" alt="image" src="https://github.com/jenkinsci/github-oauth-plugin/assets/1361875/a43dd677-d257-4725-b5cc-7d8df40e2685">

### Testing done

Unit tests have been included in the commit.

This has been deployed to production on our instance and it's been working well. We use the CasC plugin and so can verify that works too.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```