### PR TITLE
maven: Fix changelog format

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,3 +1,3 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
--Pchangelist.format=%d.v%s
+-Dchangelist.format=%d.v%s


### PR DESCRIPTION
There was a typo in the maven config 🤦

The `incrementals-tools` tool uses `-rc%d.%s` as the default changelist format (instead of the desired `%d.v%s` as per the plugin guide). I think this is what caused the latest release build to fail, due to the tag starting with a `-`.

```
[INFO] Setting: -Dchangelist=-rc586.88708ce878fc -DscmTag=88708ce878fc051841ea8ab32749d51e0f89ea08
...
gh api -F tag=-rc586.88708ce878fc -F message=-rc586.88708ce878fc -F object=88708ce878fc051841ea8ab32749d51e0f89ea08 -F type=commit /repos/jenkinsci/github-oauth-plugin/git/tags
gh: Could not verify tag name (HTTP 422)
```

https://github.com/jenkinsci/github-oauth-plugin/actions/runs/5709233552

### Testing done

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
