### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,9 +6,10 @@ buildPlugin(
   useContainerAgent: true,
   // Show failures on all configurations
   failFast: false,
-  // Test Java 11 with default Jenkins version, Java 17 with more recent LTS
+  // Test Java 11, 17, and 21
   configurations: [
-    [platform: 'linux',   jdk: '17', jenkins: '2.387.1'],
+    [platform: 'linux',   jdk: '17'],
+    [platform: 'linux',   jdk: '21', jenkins: '2.414'],
     [platform: 'windows', jdk: '11']
   ]
 )


### PR DESCRIPTION
## Test with Java 21

Java 21 is scheduled to release September 19, 2023.  We'd like to be ready to support it soon after it releases.  Run plugin tests with Java 21 as preparation.

### Testing done

Confirmed that automated tests pass

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
