### PR TITLE
[JENKINS-72268] Missing permission due to desync with cache

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
@@ -504,6 +504,9 @@ public class GithubAuthenticationToken extends AbstractAuthenticationToken {
                 // Also stick into usersByIdCache (to have latest copy)
                 String username = ghMyself.getLogin();
                 usersByIdCache.put(username, new GithubUser(ghMyself));
+            } else {
+                // force creation of the gh variable, esp. in case of impersonation
+                getGitHub();
             }
         } catch (IOException e) {
             LOGGER.log(Level.INFO, e.getMessage(), e);

--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -753,10 +753,15 @@ public class GithubSecurityRealm extends AbstractPasswordBasedSecurityRealm impl
     @Override
     public GroupDetails loadGroupByGroupname(String groupName)
             throws UsernameNotFoundException, DataAccessException {
-        GithubAuthenticationToken authToken =  (GithubAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
-
-        if(authToken == null)
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
             throw new UsernameNotFoundException("No known group: " + groupName);
+        }
+        if (!(authentication instanceof GithubAuthenticationToken)) {
+            throw new UserMayOrMayNotExistException("The received token is not a GitHub one");
+        }
+
+        GithubAuthenticationToken authToken = (GithubAuthenticationToken) authentication;
 
         try {
             int idx = groupName.indexOf(GithubOAuthGroupDetails.ORG_TEAM_SEPARATOR);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Should resolves [JENKINS-72268](https://issues.jenkins.io/browse/JENKINS-72268) and potentially [JENKINS-72209](https://issues.jenkins.io/browse/JENKINS-72209).

The `gh` variable is set for a token only when the cache does not contain the username ([code](https://github.com/jenkinsci/github-oauth-plugin/blob/818ad9b1211b919aa2d8d417451d126fee4424a2/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java#L499-L510)). But, if you are using impersonation, like in situations explained in the ticket, the cache will contain the token and thus, me != null, leading to a token with gh=null.
Due to this, the authorities are [not loaded](https://github.com/jenkinsci/github-oauth-plugin/blob/f637f211eecea88a8564bde00f7fd88be3e3ad75/src/main/java/org/jenkinsci/plugins/GithubOAuthUserDetails.java#L46) because the gh is null.


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

I tested with and without the user in my local storage (same behavior). The impersonation did not work before and now is working as expected.

The second commit is about a cast exception being thrown when trying to request the group information without directly using the expected token. Better to return the expected exception instead. Tested before and after, the behavior is "cleaner".

Due to the number of manual tests I did using breakpoints here and there to reproduce the problem and understand the source, I am not sure I can write a unit test without spending 4-5x the time.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
