### PR TITLE
Revert "[JENKINS-72268]" due to reported performance degredation

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
@@ -504,9 +504,6 @@ public class GithubAuthenticationToken extends AbstractAuthenticationToken {
                 // Also stick into usersByIdCache (to have latest copy)
                 String username = ghMyself.getLogin();
                 usersByIdCache.put(username, new GithubUser(ghMyself));
-            } else {
-                // force creation of the gh variable, esp. in case of impersonation
-                getGitHub();
             }
         } catch (IOException e) {
             LOGGER.log(Level.INFO, e.getMessage(), e);

--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -753,15 +753,10 @@ public class GithubSecurityRealm extends AbstractPasswordBasedSecurityRealm impl
     @Override
     public GroupDetails loadGroupByGroupname(String groupName)
             throws UsernameNotFoundException, DataAccessException {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null) {
-            throw new UsernameNotFoundException("No known group: " + groupName);
-        }
-        if (!(authentication instanceof GithubAuthenticationToken)) {
-            throw new UserMayOrMayNotExistException("The received token is not a GitHub one");
-        }
+        GithubAuthenticationToken authToken =  (GithubAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
 
-        GithubAuthenticationToken authToken = (GithubAuthenticationToken) authentication;
+        if(authToken == null)
+            throw new UsernameNotFoundException("No known group: " + groupName);
 
         try {
             int idx = groupName.indexOf(GithubOAuthGroupDetails.ORG_TEAM_SEPARATOR);


### PR DESCRIPTION
As it was reported that a performance issue came up (see https://github.com/jenkinsci/github-oauth-plugin/pull/256#issuecomment-1791969578) I'm rolling back the change to allow time for proper investigation / reproduction in a test environment.

Until we re-introduce the change, users of the feature can pin to [`596.v0646c4a_0a_962`](https://github.com/jenkinsci/github-oauth-plugin/releases/tag/596.v0646c4a_0a_962).