### PR TITLE
Migrate from Acegi compatibility layer to Spring Security 6.x

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubOAuthUserDetails.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubOAuthUserDetails.java
@@ -5,11 +5,10 @@ package org.jenkinsci.plugins;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.io.IOException;
-import org.acegisecurity.GrantedAuthority;
-import org.acegisecurity.userdetails.User;
-import org.acegisecurity.userdetails.UserDetails;
-import org.kohsuke.github.GHUser;
+import java.util.Collection;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 
 /**
  * @author Mike
@@ -20,34 +19,8 @@ public class GithubOAuthUserDetails extends User implements UserDetails {
 
     private static final long serialVersionUID = 1L;
 
-    private boolean hasGrantedAuthorities;
-
-    private final GithubAuthenticationToken authenticationToken;
-
-    public GithubOAuthUserDetails(@NonNull String login, @NonNull GrantedAuthority[] authorities) {
+    public GithubOAuthUserDetails(@NonNull String login, @NonNull Collection<? extends GrantedAuthority> authorities) {
         super(login, "", true, true, true, true, authorities);
-        this.authenticationToken = null;
-        this.hasGrantedAuthorities = true;
     }
 
-    public GithubOAuthUserDetails(@NonNull String login, @NonNull GithubAuthenticationToken authenticationToken) {
-        super(login, "", true, true, true, true, new GrantedAuthority[0]);
-        this.authenticationToken = authenticationToken;
-        this.hasGrantedAuthorities = false;
-    }
-
-    @Override
-    public GrantedAuthority[] getAuthorities() {
-        if (!hasGrantedAuthorities) {
-            try {
-                GHUser user = authenticationToken.loadUser(getUsername());
-                if(user != null) {
-                    setAuthorities(authenticationToken.getAuthorities());
-                }
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        return super.getAuthorities();
-    }
 }

--- a/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
@@ -45,12 +45,12 @@ import java.util.logging.Logger;
 import jenkins.branch.MultiBranchProject;
 import jenkins.model.Jenkins;
 import jenkins.scm.api.SCMSource;
-import org.acegisecurity.Authentication;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.multibranch.BranchJobProperty;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.springframework.security.core.Authentication;
 
 /**
  * @author Mike
@@ -76,11 +76,11 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
     /*
      * (non-Javadoc)
      *
-     * @see hudson.security.ACL#hasPermission(org.acegisecurity.Authentication,
+     * @see hudson.security.ACL#hasPermission(org.springframework.security.core.Authentication,
      * hudson.security.Permission)
      */
     @Override
-    public boolean hasPermission(@NonNull Authentication a, @NonNull Permission permission) {
+    public boolean hasPermission2(@NonNull Authentication a, @NonNull Permission permission) {
         if (a instanceof GithubAuthenticationToken) {
             if (!a.isAuthenticated())
                 return false;
@@ -153,7 +153,7 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
                 throw new IllegalArgumentException("Authentication must have a valid name");
             }
 
-            if (authenticatedUserName.equals(SYSTEM.getPrincipal())) {
+            if (authenticatedUserName.equals(SYSTEM2.getPrincipal())) {
                 // give system user full access
                 log.finest("Granting Full rights to SYSTEM user.");
                 return true;
@@ -233,7 +233,7 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 
     @Nullable
     private String requestURI() {
-        StaplerRequest currentRequest = Stapler.getCurrentRequest();
+        StaplerRequest2 currentRequest = Stapler.getCurrentRequest2();
         return (currentRequest == null) ? null : currentRequest.getOriginalRequestURI();
     }
 

--- a/src/test/java/org/jenkinsci/plugins/GithubLogoutActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubLogoutActionTest.java
@@ -24,36 +24,24 @@ THE SOFTWARE.
 
 package org.jenkinsci.plugins;
 
+import static org.junit.Assert.assertEquals;
+
 import jenkins.model.Jenkins;
-import junit.framework.TestCase;
-import org.jenkinsci.plugins.GithubSecurityRealm.DescriptorImpl;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
 
-public class GithubLogoutActionTest extends TestCase {
+@RunWith(MockitoJUnitRunner.class)
+public class GithubLogoutActionTest {
 
     @Mock
     private GithubSecurityRealm securityRealm;
 
     @Mock
-    private DescriptorImpl descriptor;
-
-    private AutoCloseable closeable;
-
-    @Before
-    public void setUp() {
-        closeable = MockitoAnnotations.openMocks(this);
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        closeable.close();
-    }
+    private GithubSecurityRealm.DescriptorImpl descriptor;
 
     private void mockJenkins(MockedStatic<Jenkins> mockedJenkins) {
         Jenkins jenkins = Mockito.mock(Jenkins.class);

--- a/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACLTest.java
@@ -47,10 +47,6 @@ import jenkins.branch.Branch;
 import jenkins.branch.MultiBranchProject;
 import jenkins.model.Jenkins;
 import jenkins.scm.api.SCMSource;
-import org.acegisecurity.Authentication;
-import org.acegisecurity.GrantedAuthority;
-import org.acegisecurity.GrantedAuthorityImpl;
-import org.acegisecurity.providers.anonymous.AnonymousAuthenticationToken;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.multibranch.BranchJobProperty;
@@ -67,11 +63,14 @@ import org.kohsuke.github.PagedIterable;
 import org.kohsuke.github.RateLimitHandler;
 import org.kohsuke.github.extras.okhttp3.OkHttpGitHubConnector;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 /**
  *
@@ -126,7 +125,7 @@ public class GithubRequireOrganizationMembershipACLTest {
             PermissionScope.ITEM);
     private final Authentication ANONYMOUS_USER = new AnonymousAuthenticationToken("anonymous",
             "anonymous",
-            new GrantedAuthority[]{new GrantedAuthorityImpl("anonymous")});
+            List.of(new SimpleGrantedAuthority("anonymous")));
 
     private GithubRequireOrganizationMembershipACL createACL() {
         GithubRequireOrganizationMembershipACL acl = new GithubRequireOrganizationMembershipACL(
@@ -254,15 +253,15 @@ public class GithubRequireOrganizationMembershipACLTest {
             GithubRequireOrganizationMembershipACL projectAcl = aclForProject(mockProject);
             GithubAuthenticationToken authenticationToken = new GithubAuthenticationToken("accessToken", "https://api.github.com");
 
-            assertTrue(projectAcl.hasPermission(authenticationToken, Item.READ));
-            assertTrue(projectAcl.hasPermission(authenticationToken, Item.DISCOVER));
-            assertTrue(projectAcl.hasPermission(authenticationToken, Item.BUILD));
-            assertTrue(workflowJobAcl.hasPermission(authenticationToken, Item.READ));
-            assertTrue(workflowJobAcl.hasPermission(authenticationToken, Item.DISCOVER));
-            assertTrue(workflowJobAcl.hasPermission(authenticationToken, Item.BUILD));
-            assertTrue(multiBranchProjectAcl.hasPermission(authenticationToken, Item.READ));
-            assertTrue(multiBranchProjectAcl.hasPermission(authenticationToken, Item.DISCOVER));
-            assertTrue(multiBranchProjectAcl.hasPermission(authenticationToken, Item.BUILD));
+            assertTrue(projectAcl.hasPermission2(authenticationToken, Item.READ));
+            assertTrue(projectAcl.hasPermission2(authenticationToken, Item.DISCOVER));
+            assertTrue(projectAcl.hasPermission2(authenticationToken, Item.BUILD));
+            assertTrue(workflowJobAcl.hasPermission2(authenticationToken, Item.READ));
+            assertTrue(workflowJobAcl.hasPermission2(authenticationToken, Item.DISCOVER));
+            assertTrue(workflowJobAcl.hasPermission2(authenticationToken, Item.BUILD));
+            assertTrue(multiBranchProjectAcl.hasPermission2(authenticationToken, Item.READ));
+            assertTrue(multiBranchProjectAcl.hasPermission2(authenticationToken, Item.DISCOVER));
+            assertTrue(multiBranchProjectAcl.hasPermission2(authenticationToken, Item.BUILD));
         }
     }
 
@@ -282,15 +281,15 @@ public class GithubRequireOrganizationMembershipACLTest {
             GithubRequireOrganizationMembershipACL projectAcl = aclForProject(mockProject);
             GithubAuthenticationToken authenticationToken = new GithubAuthenticationToken("accessToken", "https://api.github.com");
 
-            assertTrue(projectAcl.hasPermission(authenticationToken, Item.READ));
-            assertTrue(projectAcl.hasPermission(authenticationToken, Item.DISCOVER));
-            assertTrue(projectAcl.hasPermission(authenticationToken, Item.BUILD));
-            assertTrue(workflowJobAcl.hasPermission(authenticationToken, Item.READ));
-            assertTrue(workflowJobAcl.hasPermission(authenticationToken, Item.DISCOVER));
-            assertTrue(workflowJobAcl.hasPermission(authenticationToken, Item.BUILD));
-            assertTrue(multiBranchProjectAcl.hasPermission(authenticationToken, Item.READ));
-            assertTrue(multiBranchProjectAcl.hasPermission(authenticationToken, Item.DISCOVER));
-            assertTrue(multiBranchProjectAcl.hasPermission(authenticationToken, Item.BUILD));
+            assertTrue(projectAcl.hasPermission2(authenticationToken, Item.READ));
+            assertTrue(projectAcl.hasPermission2(authenticationToken, Item.DISCOVER));
+            assertTrue(projectAcl.hasPermission2(authenticationToken, Item.BUILD));
+            assertTrue(workflowJobAcl.hasPermission2(authenticationToken, Item.READ));
+            assertTrue(workflowJobAcl.hasPermission2(authenticationToken, Item.DISCOVER));
+            assertTrue(workflowJobAcl.hasPermission2(authenticationToken, Item.BUILD));
+            assertTrue(multiBranchProjectAcl.hasPermission2(authenticationToken, Item.READ));
+            assertTrue(multiBranchProjectAcl.hasPermission2(authenticationToken, Item.DISCOVER));
+            assertTrue(multiBranchProjectAcl.hasPermission2(authenticationToken, Item.BUILD));
         }
     }
 
@@ -313,15 +312,15 @@ public class GithubRequireOrganizationMembershipACLTest {
 
             GithubAuthenticationToken authenticationToken = new GithubAuthenticationToken("accessToken", "https://api.github.com");
 
-            assertTrue(projectAcl.hasPermission(authenticationToken, Item.READ));
-            assertTrue(projectAcl.hasPermission(authenticationToken, Item.DISCOVER));
-            assertTrue(projectAcl.hasPermission(authenticationToken, Item.BUILD));
-            assertTrue(workflowJobAcl.hasPermission(authenticationToken, Item.READ));
-            assertTrue(workflowJobAcl.hasPermission(authenticationToken, Item.DISCOVER));
-            assertTrue(workflowJobAcl.hasPermission(authenticationToken, Item.BUILD));
-            assertTrue(multiBranchProjectAcl.hasPermission(authenticationToken, Item.READ));
-            assertTrue(multiBranchProjectAcl.hasPermission(authenticationToken, Item.DISCOVER));
-            assertTrue(multiBranchProjectAcl.hasPermission(authenticationToken, Item.BUILD));
+            assertTrue(projectAcl.hasPermission2(authenticationToken, Item.READ));
+            assertTrue(projectAcl.hasPermission2(authenticationToken, Item.DISCOVER));
+            assertTrue(projectAcl.hasPermission2(authenticationToken, Item.BUILD));
+            assertTrue(workflowJobAcl.hasPermission2(authenticationToken, Item.READ));
+            assertTrue(workflowJobAcl.hasPermission2(authenticationToken, Item.DISCOVER));
+            assertTrue(workflowJobAcl.hasPermission2(authenticationToken, Item.BUILD));
+            assertTrue(multiBranchProjectAcl.hasPermission2(authenticationToken, Item.READ));
+            assertTrue(multiBranchProjectAcl.hasPermission2(authenticationToken, Item.DISCOVER));
+            assertTrue(multiBranchProjectAcl.hasPermission2(authenticationToken, Item.BUILD));
         }
     }
 
@@ -342,15 +341,15 @@ public class GithubRequireOrganizationMembershipACLTest {
 
             GithubAuthenticationToken authenticationToken = new GithubAuthenticationToken("accessToken", "https://api.github.com");
 
-            assertFalse(projectAcl.hasPermission(authenticationToken, Item.READ));
-            assertFalse(projectAcl.hasPermission(authenticationToken, Item.DISCOVER));
-            assertFalse(projectAcl.hasPermission(authenticationToken, Item.BUILD));
-            assertFalse(multiBranchProjectAcl.hasPermission(authenticationToken, Item.READ));
-            assertFalse(multiBranchProjectAcl.hasPermission(authenticationToken, Item.DISCOVER));
-            assertFalse(multiBranchProjectAcl.hasPermission(authenticationToken, Item.BUILD));
-            assertFalse(workflowJobAcl.hasPermission(authenticationToken, Item.READ));
-            assertFalse(workflowJobAcl.hasPermission(authenticationToken, Item.DISCOVER));
-            assertFalse(workflowJobAcl.hasPermission(authenticationToken, Item.BUILD));
+            assertFalse(projectAcl.hasPermission2(authenticationToken, Item.READ));
+            assertFalse(projectAcl.hasPermission2(authenticationToken, Item.DISCOVER));
+            assertFalse(projectAcl.hasPermission2(authenticationToken, Item.BUILD));
+            assertFalse(multiBranchProjectAcl.hasPermission2(authenticationToken, Item.READ));
+            assertFalse(multiBranchProjectAcl.hasPermission2(authenticationToken, Item.DISCOVER));
+            assertFalse(multiBranchProjectAcl.hasPermission2(authenticationToken, Item.BUILD));
+            assertFalse(workflowJobAcl.hasPermission2(authenticationToken, Item.READ));
+            assertFalse(workflowJobAcl.hasPermission2(authenticationToken, Item.DISCOVER));
+            assertFalse(workflowJobAcl.hasPermission2(authenticationToken, Item.BUILD));
         }
     }
 
@@ -367,8 +366,8 @@ public class GithubRequireOrganizationMembershipACLTest {
 
             GithubAuthenticationToken authenticationToken = new GithubAuthenticationToken("accessToken", "https://api.github.com");
 
-            assertFalse(acl.hasPermission(authenticationToken, Item.READ));
-            assertFalse(acl.hasPermission(authenticationToken, Item.DISCOVER));
+            assertFalse(acl.hasPermission2(authenticationToken, Item.READ));
+            assertFalse(acl.hasPermission2(authenticationToken, Item.DISCOVER));
         }
     }
 
@@ -383,8 +382,8 @@ public class GithubRequireOrganizationMembershipACLTest {
 
             GithubAuthenticationToken authenticationToken = new GithubAuthenticationToken("accessToken", "https://api.github.com");
 
-            assertFalse(acl.hasPermission(authenticationToken, Item.READ));
-            assertFalse(acl.hasPermission(authenticationToken, Item.DISCOVER));
+            assertFalse(acl.hasPermission2(authenticationToken, Item.READ));
+            assertFalse(acl.hasPermission2(authenticationToken, Item.DISCOVER));
         }
     }
 
@@ -405,8 +404,8 @@ public class GithubRequireOrganizationMembershipACLTest {
 
             GithubAuthenticationToken authenticationToken = new GithubAuthenticationToken("accessToken", "https://api.github.com");
 
-            assertFalse(acl.hasPermission(authenticationToken, Item.READ));
-            assertFalse(acl.hasPermission(authenticationToken, Item.DISCOVER));
+            assertFalse(acl.hasPermission2(authenticationToken, Item.READ));
+            assertFalse(acl.hasPermission2(authenticationToken, Item.DISCOVER));
         }
     }
 
@@ -422,7 +421,7 @@ public class GithubRequireOrganizationMembershipACLTest {
             GithubRequireOrganizationMembershipACL acl = createACL();
             GithubAuthenticationToken authenticationToken = new GithubAuthenticationToken("accessToken", "https://api.github.com");
 
-            assertTrue(acl.hasPermission(authenticationToken, Hudson.READ));
+            assertTrue(acl.hasPermission2(authenticationToken, Hudson.READ));
         }
     }
 
@@ -438,7 +437,7 @@ public class GithubRequireOrganizationMembershipACLTest {
             GithubRequireOrganizationMembershipACL acl = createACL();
             GithubAuthenticationToken authenticationToken = new GithubAuthenticationToken("accessToken", "https://api.github.com");
 
-            assertTrue(acl.hasPermission(authenticationToken, Item.READ));
+            assertTrue(acl.hasPermission2(authenticationToken, Item.READ));
         }
     }
 
@@ -454,7 +453,7 @@ public class GithubRequireOrganizationMembershipACLTest {
             GithubRequireOrganizationMembershipACL acl = createACL();
             GithubAuthenticationToken authenticationToken = new GithubAuthenticationToken("accessToken", "https://api.github.com");
 
-            assertFalse(acl.hasPermission(authenticationToken, Item.READ));
+            assertFalse(acl.hasPermission2(authenticationToken, Item.READ));
         }
     }
 
@@ -469,7 +468,7 @@ public class GithubRequireOrganizationMembershipACLTest {
             GithubRequireOrganizationMembershipACL acl = createACL();
             GithubAuthenticationToken authenticationToken = new GithubAuthenticationToken("accessToken", "https://api.github.com");
 
-            assertFalse(acl.hasPermission(authenticationToken, Item.CREATE));
+            assertFalse(acl.hasPermission2(authenticationToken, Item.CREATE));
         }
     }
 
@@ -484,7 +483,7 @@ public class GithubRequireOrganizationMembershipACLTest {
             GithubRequireOrganizationMembershipACL acl = createACL();
             GithubAuthenticationToken authenticationToken = new GithubAuthenticationToken("accessToken", "https://api.github.com");
 
-            assertTrue(acl.hasPermission(authenticationToken, Item.CREATE));
+            assertTrue(acl.hasPermission2(authenticationToken, Item.CREATE));
         }
     }
 
@@ -502,14 +501,14 @@ public class GithubRequireOrganizationMembershipACLTest {
             GithubAuthenticationToken authenticationToken = new GithubAuthenticationToken("accessToken", "https://api.github.com");
 
             // Gives the user rights to see the project
-            assertTrue(acl.hasPermission(authenticationToken, Item.READ));
-            assertTrue(acl.hasPermission(authenticationToken, Item.DISCOVER));
+            assertTrue(acl.hasPermission2(authenticationToken, Item.READ));
+            assertTrue(acl.hasPermission2(authenticationToken, Item.DISCOVER));
             // but not to build, cancel, configure, view configuration, delete it
-            assertFalse(acl.hasPermission(authenticationToken, Item.BUILD));
-            assertFalse(acl.hasPermission(authenticationToken, Item.CONFIGURE));
-            assertFalse(acl.hasPermission(authenticationToken, Item.DELETE));
-            assertFalse(acl.hasPermission(authenticationToken, Item.EXTENDED_READ));
-            assertFalse(acl.hasPermission(authenticationToken, Item.CANCEL));
+            assertFalse(acl.hasPermission2(authenticationToken, Item.BUILD));
+            assertFalse(acl.hasPermission2(authenticationToken, Item.CONFIGURE));
+            assertFalse(acl.hasPermission2(authenticationToken, Item.DELETE));
+            assertFalse(acl.hasPermission2(authenticationToken, Item.EXTENDED_READ));
+            assertFalse(acl.hasPermission2(authenticationToken, Item.CANCEL));
         }
     }
 
@@ -526,13 +525,13 @@ public class GithubRequireOrganizationMembershipACLTest {
             GithubRequireOrganizationMembershipACL acl = aclForProject(mockProject);
             GithubAuthenticationToken authenticationToken = new GithubAuthenticationToken("accessToken", "https://api.github.com");
 
-            assertFalse(acl.hasPermission(authenticationToken, Item.READ));
-            assertFalse(acl.hasPermission(authenticationToken, Item.DISCOVER));
-            assertFalse(acl.hasPermission(authenticationToken, Item.BUILD));
-            assertFalse(acl.hasPermission(authenticationToken, Item.CONFIGURE));
-            assertFalse(acl.hasPermission(authenticationToken, Item.DELETE));
-            assertFalse(acl.hasPermission(authenticationToken, Item.EXTENDED_READ));
-            assertFalse(acl.hasPermission(authenticationToken, Item.CANCEL));
+            assertFalse(acl.hasPermission2(authenticationToken, Item.READ));
+            assertFalse(acl.hasPermission2(authenticationToken, Item.DISCOVER));
+            assertFalse(acl.hasPermission2(authenticationToken, Item.BUILD));
+            assertFalse(acl.hasPermission2(authenticationToken, Item.CONFIGURE));
+            assertFalse(acl.hasPermission2(authenticationToken, Item.DELETE));
+            assertFalse(acl.hasPermission2(authenticationToken, Item.EXTENDED_READ));
+            assertFalse(acl.hasPermission2(authenticationToken, Item.CANCEL));
         }
     }
 
@@ -551,7 +550,7 @@ public class GithubRequireOrganizationMembershipACLTest {
 
             GithubAuthenticationToken authenticationToken = new GithubAuthenticationToken("accessToken", "https://api.github.com");
 
-            assertFalse(acl.hasPermission(authenticationToken, Item.READ));
+            assertFalse(acl.hasPermission2(authenticationToken, Item.READ));
         }
     }
 
@@ -562,9 +561,9 @@ public class GithubRequireOrganizationMembershipACLTest {
         Mockito.when(authenticationToken.getName()).thenReturn("agent");
         GithubRequireOrganizationMembershipACL acl = createACL();
 
-        assertTrue(acl.hasPermission(authenticationToken, Computer.CREATE));
-        assertTrue(acl.hasPermission(authenticationToken, Computer.CONFIGURE));
-        assertTrue(acl.hasPermission(authenticationToken, Computer.CONNECT));
+        assertTrue(acl.hasPermission2(authenticationToken, Computer.CREATE));
+        assertTrue(acl.hasPermission2(authenticationToken, Computer.CONFIGURE));
+        assertTrue(acl.hasPermission2(authenticationToken, Computer.CONNECT));
     }
 
     @Test
@@ -574,9 +573,9 @@ public class GithubRequireOrganizationMembershipACLTest {
         Mockito.when(authenticationToken.getName()).thenReturn("authenticated");
         GithubRequireOrganizationMembershipACL acl = createACL();
 
-        assertFalse(acl.hasPermission(authenticationToken, Computer.CREATE));
-        assertFalse(acl.hasPermission(authenticationToken, Computer.CONFIGURE));
-        assertFalse(acl.hasPermission(authenticationToken, Computer.CONNECT));
+        assertFalse(acl.hasPermission2(authenticationToken, Computer.CREATE));
+        assertFalse(acl.hasPermission2(authenticationToken, Computer.CONFIGURE));
+        assertFalse(acl.hasPermission2(authenticationToken, Computer.CONNECT));
     }
 
     @Test
@@ -586,7 +585,7 @@ public class GithubRequireOrganizationMembershipACLTest {
         Project mockProject = mockProject("https://github.com/some-org/a-public-repo.git");
         GithubRequireOrganizationMembershipACL acl = aclForProject(mockProject);
 
-        assertTrue(acl.hasPermission(ANONYMOUS_USER, VIEW_JOBSTATUS_PERMISSION));
+        assertTrue(acl.hasPermission2(ANONYMOUS_USER, VIEW_JOBSTATUS_PERMISSION));
     }
 
     @Test
@@ -596,7 +595,7 @@ public class GithubRequireOrganizationMembershipACLTest {
         Project mockProject = mockProject("https://github.com/some-org/a-public-repo.git");
         GithubRequireOrganizationMembershipACL acl = aclForProject(mockProject);
 
-        assertFalse(acl.hasPermission(ANONYMOUS_USER, VIEW_JOBSTATUS_PERMISSION));
+        assertFalse(acl.hasPermission2(ANONYMOUS_USER, VIEW_JOBSTATUS_PERMISSION));
     }
 
     @Test
@@ -606,13 +605,13 @@ public class GithubRequireOrganizationMembershipACLTest {
             mockJenkins(mockedJenkins);
             this.allowAnonymousWebhookPermission = true;
 
-            StaplerRequest currentRequest = Mockito.mock(StaplerRequest.class);
-            mockedStapler.when(Stapler::getCurrentRequest).thenReturn(currentRequest);
+            StaplerRequest2 currentRequest = Mockito.mock(StaplerRequest2.class);
+            mockedStapler.when(Stapler::getCurrentRequest2).thenReturn(currentRequest);
             Mockito.when(currentRequest.getOriginalRequestURI()).thenReturn("https://www.jenkins.org/github-webhook/");
 
             GithubRequireOrganizationMembershipACL acl = createACL();
 
-            assertTrue(acl.hasPermission(ANONYMOUS_USER, Item.READ));
+            assertTrue(acl.hasPermission2(ANONYMOUS_USER, Item.READ));
         }
     }
 
@@ -621,13 +620,13 @@ public class GithubRequireOrganizationMembershipACLTest {
         try (MockedStatic<Stapler> mockedStapler = Mockito.mockStatic(Stapler.class)) {
             this.allowAnonymousWebhookPermission = false;
 
-            StaplerRequest currentRequest = Mockito.mock(StaplerRequest.class);
-            mockedStapler.when(Stapler::getCurrentRequest).thenReturn(currentRequest);
+            StaplerRequest2 currentRequest = Mockito.mock(StaplerRequest2.class);
+            mockedStapler.when(Stapler::getCurrentRequest2).thenReturn(currentRequest);
             Mockito.when(currentRequest.getOriginalRequestURI()).thenReturn("https://www.jenkins.org/github-webhook/");
 
             GithubRequireOrganizationMembershipACL acl = createACL();
 
-            assertFalse(acl.hasPermission(ANONYMOUS_USER, Item.READ));
+            assertFalse(acl.hasPermission2(ANONYMOUS_USER, Item.READ));
         }
     }
 
@@ -638,8 +637,8 @@ public class GithubRequireOrganizationMembershipACLTest {
         Project mockProject = mockProject("https://github.com/some-org/a-public-repo.git");
         GithubRequireOrganizationMembershipACL acl = aclForProject(mockProject);
 
-        assertTrue(acl.hasPermission(ANONYMOUS_USER, Item.READ));
-        assertTrue(acl.hasPermission(ANONYMOUS_USER, Item.DISCOVER));
+        assertTrue(acl.hasPermission2(ANONYMOUS_USER, Item.READ));
+        assertTrue(acl.hasPermission2(ANONYMOUS_USER, Item.DISCOVER));
     }
 
     @Test
@@ -649,8 +648,8 @@ public class GithubRequireOrganizationMembershipACLTest {
         Project mockProject = mockProject("https://github.com/some-org/a-public-repo.git");
         GithubRequireOrganizationMembershipACL acl = aclForProject(mockProject);
 
-        assertFalse(acl.hasPermission(ANONYMOUS_USER, Item.READ));
-        assertFalse(acl.hasPermission(ANONYMOUS_USER, Item.DISCOVER));
+        assertFalse(acl.hasPermission2(ANONYMOUS_USER, Item.READ));
+        assertFalse(acl.hasPermission2(ANONYMOUS_USER, Item.DISCOVER));
     }
 
     @Test
@@ -658,13 +657,13 @@ public class GithubRequireOrganizationMembershipACLTest {
         try (MockedStatic<Stapler> mockedStapler = Mockito.mockStatic(Stapler.class)) {
             this.allowAnonymousCCTrayPermission = true;
 
-            StaplerRequest currentRequest = Mockito.mock(StaplerRequest.class);
-            mockedStapler.when(Stapler::getCurrentRequest).thenReturn(currentRequest);
+            StaplerRequest2 currentRequest = Mockito.mock(StaplerRequest2.class);
+            mockedStapler.when(Stapler::getCurrentRequest2).thenReturn(currentRequest);
             Mockito.when(currentRequest.getOriginalRequestURI()).thenReturn("https://www.jenkins.org/cc.xml");
 
             GithubRequireOrganizationMembershipACL acl = createACL();
 
-            assertTrue(acl.hasPermission(ANONYMOUS_USER, Item.READ));
+            assertTrue(acl.hasPermission2(ANONYMOUS_USER, Item.READ));
         }
     }
 
@@ -673,13 +672,13 @@ public class GithubRequireOrganizationMembershipACLTest {
         try (MockedStatic<Stapler> mockedStapler = Mockito.mockStatic(Stapler.class)) {
             this.allowAnonymousCCTrayPermission = false;
 
-            StaplerRequest currentRequest = Mockito.mock(StaplerRequest.class);
-            mockedStapler.when(Stapler::getCurrentRequest).thenReturn(currentRequest);
+            StaplerRequest2 currentRequest = Mockito.mock(StaplerRequest2.class);
+            mockedStapler.when(Stapler::getCurrentRequest2).thenReturn(currentRequest);
             Mockito.when(currentRequest.getOriginalRequestURI()).thenReturn("https://www.jenkins.org/cc.xml");
 
             GithubRequireOrganizationMembershipACL acl = createACL();
 
-            assertFalse(acl.hasPermission(ANONYMOUS_USER, Item.READ));
+            assertFalse(acl.hasPermission2(ANONYMOUS_USER, Item.READ));
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/GithubSecurityRealmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubSecurityRealmTest.java
@@ -29,7 +29,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.jenkinsci.plugins.GithubSecurityRealm.DescriptorImpl;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -70,19 +69,19 @@ public class GithubSecurityRealmTest {
 
     @Test
     public void testDescriptorImplGetDefaultGithubWebUri() {
-        DescriptorImpl descriptor = new DescriptorImpl();
+        GithubSecurityRealm.DescriptorImpl descriptor = new GithubSecurityRealm.DescriptorImpl();
         assertEquals("https://github.com", descriptor.getDefaultGithubWebUri());
     }
 
     @Test
     public void testDescriptorImplGetDefaultGithubApiUri() {
-        DescriptorImpl descriptor = new DescriptorImpl();
+        GithubSecurityRealm.DescriptorImpl descriptor = new GithubSecurityRealm.DescriptorImpl();
         assertEquals("https://api.github.com", descriptor.getDefaultGithubApiUri());
     }
 
     @Test
     public void testDescriptorImplGetDefaultOauthScopes() {
-        DescriptorImpl descriptor = new DescriptorImpl();
+        GithubSecurityRealm.DescriptorImpl descriptor = new GithubSecurityRealm.DescriptorImpl();
         assertEquals("read:org,user:email,repo", descriptor.getDefaultOauthScopes());
     }
 }


### PR DESCRIPTION
This plugin continues to work on 2.479.x LTS, but only through a number of old compatibility layers. This is inefficient, and we cannot keep supporting these compatibility layers forever. This PR migrates away from the compatibility layers to the latest Spring Security 6.x and Jenkins APIs.

### Testing done

`mvn clean verify`

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
