### PR TITLE
[JENKINS-72209] Fix initially missing authorities

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthenticationToken.java
@@ -469,7 +469,7 @@ public class GithubAuthenticationToken extends AbstractAuthenticationToken {
         GithubUser user;
         try {
             user = usersByIdCache.getIfPresent(username);
-            if (gh != null && user == null && isAuthenticated()) {
+            if (user == null && isAuthenticated()) {
                 GHUser ghUser = getGitHub().getUser(username);
                 user = new GithubUser(ghUser);
                 usersByIdCache.put(username, user);
@@ -505,7 +505,7 @@ public class GithubAuthenticationToken extends AbstractAuthenticationToken {
     @Nullable
     GHOrganization loadOrganization(@NonNull String organization) {
         try {
-            if (gh != null && isAuthenticated())
+            if (isAuthenticated())
                 return getGitHub().getOrganization(organization);
         } catch (IOException | RuntimeException e) {
             LOGGER.log(Level.FINEST, e.getMessage(), e);
@@ -516,7 +516,7 @@ public class GithubAuthenticationToken extends AbstractAuthenticationToken {
     @NonNull
     private RepoRights loadRepository(@NonNull final String repositoryName) {
       try {
-          if (gh != null && isAuthenticated() && (myRealm.hasScope("repo") || myRealm.hasScope("public_repo"))) {
+          if (isAuthenticated() && (myRealm.hasScope("repo") || myRealm.hasScope("public_repo"))) {
               Cache<String, RepoRights> repoNameToRightsCache = myRepositories();
               return repoNameToRightsCache.get(repositoryName, unused -> {
                         GHRepository repo;

--- a/src/test/java/org/jenkinsci/plugins/GithubAuthenticationTokenTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubAuthenticationTokenTest.java
@@ -49,7 +49,7 @@ class GithubAuthenticationTokenTest {
             assertEquals(deserializedToken.getAccessToken(), authenticationToken.getAccessToken());
             assertEquals(deserializedToken.getPrincipal(), authenticationToken.getPrincipal());
             assertEquals(deserializedToken.getGithubServer(), authenticationToken.getGithubServer());
-            assertEquals(deserializedToken.getMyself().getLogin(), deserializedToken.getMyself().getLogin());
+            assertEquals(deserializedToken.getMyself().getLogin(), authenticationToken.getMyself().getLogin());
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/GithubAuthenticationTokenTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GithubAuthenticationTokenTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ExtendWith(MockitoExtension.class)
 class GithubAuthenticationTokenTest {
 
-    @Mock(strictness = Mock.Strictness.LENIENT)
+    @Mock
     private GithubSecurityRealm securityRealm;
 
     @AfterEach
@@ -34,7 +34,7 @@ class GithubAuthenticationTokenTest {
         Jenkins jenkins = Mockito.mock(Jenkins.class);
         mockedJenkins.when(Jenkins::get).thenReturn(jenkins);
         Mockito.when(jenkins.getSecurityRealm()).thenReturn(securityRealm);
-        Mockito.when(securityRealm.getOauthScopes()).thenReturn("read:org");
+        Mockito.when(securityRealm.hasScope("read:org")).thenReturn(true);
     }
 
     @Test


### PR DESCRIPTION
This should fix the following issues:

 * https://issues.jenkins.io/browse/JENKINS-63296
 * https://issues.jenkins.io/browse/JENKINS-72209
 * https://issues.jenkins.io/browse/JENKINS-72268
 * https://issues.jenkins.io/browse/JENKINS-73060

Unlike https://github.com/jenkinsci/github-oauth-plugin/pull/256, I don't believe this will cause a performance regression.

In https://github.com/jenkinsci/github-oauth-plugin/pull/61, use of `gh` was replaced by `getGitHub()` but the check for `gh != null` was not removed. `getGitHub()` already ensures that it's present so there's no need to do the check.

The check was causing calls to `loadUser`, etc to return `null` if a token was restored and nothing that transitively calls `getGitHub()` has been called yet.

In particular, when a user logs in, their authorities will be empty because GithubSecurityRealm tries to `loadUser` in `loadUserByUsername2` and sets authorities to empty if the user is `null`. Only later, when something transitively calls `getGitHub()`, will the user have the authorities set.

### Testing done

I've added a unit test that checks that `loadUser` works after deserialization.

I also tested manually on a local Jenkins instance with:

1. Log out
2. Log in via Github
3. Go to http://$JENKINS_URL/user/$username/
4. Check that you have Groups

Prior to this PR, Groups would be empty immediately after logging in. Only a few minutes later it might get populated. With this PR, groups will be populated even after logging in immediately.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
