### PR TITLE
[JENKINS-73060] Fix missing authorities

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -695,19 +695,7 @@ public class GithubSecurityRealm extends AbstractPasswordBasedSecurityRealm {
          * Taken from hudson.security.HudsonPrivateSecurityRealm#loadUserByUsername(java.lang.String)
          */
         if (localUser != null) {
-            GHUser user;
-            try {
-                user = authToken.loadUser(username);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-            Collection<GrantedAuthority> authorities;
-            if (user != null) {
-                authorities = authToken.getAuthorities();
-            } else {
-                authorities = List.of();
-            }
-            return new GithubOAuthUserDetails(username, authorities);
+            return new GithubOAuthUserDetails(username, authToken.getAuthorities());
         }
 
         try {


### PR DESCRIPTION
This should fix [JENKINS-73060](https://issues.jenkins.io/browse/JENKINS-73060).

This updates `loadByUsername2` to always use the authorities retrieved in the `GithubAuthenticationToken` when constructing the `GithubOAuthUserDetails` object. Previously, this plugin would try to load a `GHUser` object (either from the `userByIdCache` or the Github API) and would pass an empty list of authorities when the `GHUser` was `null`. 

I couldn't find a logical reason for why we would need this check when we do not use the `GHUser` object to set the authorities. This check seems to be a carry over from when the `GHUser` was used in the `getGrantedAuthorities` method to fetch/set authorities before https://github.com/jenkinsci/github-oauth-plugin/commit/99e3d1350d68a549e0ca44f39ad687d227235638.

There's also a secondary bug here where `loadUser` will not make the API call to retrieve the `GHUser` from the Github API if `gh` is `null` (which is usually the case when the token used to construct `GithubAuthenticationToken` is in the `usersByTokenCache`). This null check shouldn't be needed due to changes introduced in https://github.com/jenkinsci/github-oauth-plugin/pull/61. However, I chose not to remove this check due to possible performance degradation as seen in https://github.com/jenkinsci/github-oauth-plugin/pull/256. 

### Testing done

We've been running this patch in our Production environment without issue since June 12. We're not seeing any performance degradation on our Jenkins instance with this patch.

<details>
  <summary>Steps to Reproduce</summary>

  1. Clone this project & execute `mvn hpi:run` 
  1. Install the following additional plugins:
      - `Authorize Project`
      - `Role-based Authorization Strategy`
  1. Configure the Github plugin as the security realm
  1. Configure `Authorization` to use the `Role-Based Strategy`
  1. Assign a Github team (i.e. `ORG*TEAMNAME`) the default `admin` permission in `<jenkins_url>/manage/role-strategy/assign-roles`
      - Uncheck all other assignments
      - Make sure you are a part of the team you are assigning the permissions to
  1. Configure `Access Control for Builds` to use `Project default Build Authorization` -> `Run as User who Triggered Build`
  1. Create a pipeline
      <details>
          <summary>Example</summary>
          
        ```groovy
          pipeline {
            agent any
            stages {
              stage('Test') {
                steps { echo "Hello world!" }
              }
            }
          }
        ```
      </details>
  1. Navigate to the build page -> Select `log out` in the top right -> Hit back button -> Select `Build Now`
      - Build should hang for roughly 1 minute with the following error even though the user should be a member of a Github team with `admin` permissions on the Jenkins instance.
        
        ```text
        '<username>' lacks permissions to run on 'Jenkins'
        ``` 
  1. Install this patch
  1. Navigate to the build page -> Select `log out` in the top right -> Hit back button -> Select `Build Now`
  1. Issue should no longer occur
</details>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
